### PR TITLE
rust: Initial implementation based on the aesni crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ matrix:
   - env: SUITE="ruby"
     language: ruby
     rvm: 2.2.2
-  - env: SUITE="rust"
-    language: rust
-    rust: stable
+  # TODO: support stable Rust
   - env: SUITE="rust"
     language: rust
     rust: nightly

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1,4 +1,79 @@
 [root]
 name = "miscreant"
 version = "0.0.0"
+dependencies = [
+ "aesni 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "data-encoding 2.0.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 0.2.0 (git+https://github.com/isislovecruft/subtle)",
+]
 
+[[package]]
+name = "aesni"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "arrayref"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "data-encoding"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "dtoa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itoa"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-traits"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "subtle"
+version = "0.2.0"
+source = "git+https://github.com/isislovecruft/subtle#b415469005e875326579572df33aeabd1ba4a091"
+
+[metadata]
+"checksum aesni 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "341c18a4ead1b3e3858e013473455dd24df63118308e548b9796187f17ab5ba7"
+"checksum arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd1479b7c29641adbd35ff3b5c293922d696a92f25c8c975da3e0acbc87258f"
+"checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
+"checksum data-encoding 2.0.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c48768b270ab6458e2fba295bd3593f76d22058945afb5bdc6a1b1436511402b"
+"checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
+"checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
+"checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
+"checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"
+"checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
+"checksum subtle 0.2.0 (git+https://github.com/isislovecruft/subtle)" = "<none>"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,15 @@ authors     = ["Tony Arcieri <bascule@gmail.com>"]
 homepage    = "https://miscreant.org"
 repository  = "https://github.com/miscreant/miscreant/tree/master/rust"
 readme      = "README.md"
-categories  = ["cryptography"]
+categories  = ["cryptography", "no-std"]
 keywords    = ["cryptography", "encryption", "security", "streaming"]
 
 [dependencies]
+aesni = "0.1"
+arrayref = "0.3"
+byteorder = { version = "1.1", default-features = false, features = ["i128"] }
+subtle = { git = "https://github.com/isislovecruft/subtle", default-features = false }
+
+[dev-dependencies]
+data-encoding = "2.0.0-rc.1"
+serde_json = "1"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # miscreant.rs [![crate][crate-image]][crate-link] [![Build Status][build-image]][build-link] [![MIT licensed][license-image]][license-link] [![Gitter Chat][gitter-image]][gitter-link]
 
-[crate-shield]: https://img.shields.io/crates/v/miscreant.svg
+[crate-image]: https://img.shields.io/crates/v/miscreant.svg
 [crate-link]: https://crates.io/crates/miscreant
 [build-image]: https://secure.travis-ci.org/miscreant/miscreant.svg?branch=master
 [build-link]: http://travis-ci.org/miscreant/miscreant
@@ -38,7 +38,7 @@ For more information, see the [toplevel README.md].
 
 Have questions? Want to suggest a feature or change?
 
-* [Gitter]: web-based chat about miscreant projects including **miscreant.rb**
+* [Gitter]: web-based chat about **Miscreant** projects including **miscreant.rs**
 * [Google Group]: join via web or email ([miscreant-crypto+subscribe@googlegroups.com])
 
 [Gitter]: https://gitter.im/miscreant/Lobby
@@ -49,7 +49,35 @@ Have questions? Want to suggest a feature or change?
 
 Though this library is written by cryptographic professionals, it has not
 undergone a thorough security audit, and cryptographic professionals are still
-humans that make mistakes. Use this library at your own risk.
+humans that make mistakes.
+
+This library makes an effort to use constant time operations throughout its
+implementation, however actual constant time behavior has not been verified.
+Furthermore to accomplish this, unsafe Rust features including inline assembly
+have been used. The correct operation of this unsafe code has not been
+thoroughly reviewed.
+
+Use this library at your own risk.
+
+## Requirements
+
+This library presently requires the following:
+
+* **x86_64** CPU architecture
+* Rust **nightly** compiler
+
+This library implements the AES cipher using the [aesni] crate, which
+uses the [Intel AES-NI] CPU instructions to provide a fast, constant-time
+hardware-based implementation. No software-only implementation of AES is
+provided. Additionally it includes Intel assembly language implementations of
+certain secret-dependent functions which have verified constant-time operation.
+
+This library also makes use of certain nightly-only features including inline
+assembly and `repr_align`. Supporting stable Rust will first require upstream
+changes in the [aesni] crate, which is also nightly-only.
+
+[aesni]: https://github.com/RustCrypto/block-ciphers
+[Intel AES-NI]: https://software.intel.com/en-us/blogs/2012/01/11/aes-ni-in-laymens-terms
 
 ## Contributing
 

--- a/rust/src/internals/aes.rs
+++ b/rust/src/internals/aes.rs
@@ -1,0 +1,56 @@
+//! `internals/aes.rs`: The Advanced Encryption Standard block cipher
+
+use super::{Block, BlockCipher};
+
+extern crate aesni;
+
+use self::aesni::Aes128 as Aes128Ni;
+use self::aesni::Aes256 as Aes256Ni;
+
+/// AES with a 128-bit key
+#[derive(Clone)]
+pub struct Aes128 {
+    cipher: Aes128Ni,
+}
+
+impl Aes128 {
+    /// Create a new AES-128 cipher instance from the given key
+    #[inline]
+    pub fn new(key: &[u8; 16]) -> Self {
+        Self { cipher: Aes128Ni::new(key) }
+    }
+}
+
+impl BlockCipher for Aes128 {
+    const KEY_SIZE: usize = 16;
+
+    /// Encrypt an AES block in-place
+    #[inline]
+    fn encrypt(&self, block: &mut Block) {
+        self.cipher.encrypt(block.as_mut())
+    }
+}
+
+/// AES with a 256-bit key
+#[derive(Clone)]
+pub struct Aes256 {
+    cipher: Aes256Ni,
+}
+
+impl Aes256 {
+    /// Create a new AES-256 cipher instance from the given key
+    #[inline]
+    pub fn new(key: &[u8; 32]) -> Self {
+        Self { cipher: Aes256Ni::new(key) }
+    }
+}
+
+impl BlockCipher for Aes256 {
+    const KEY_SIZE: usize = 32;
+
+    /// Encrypt an AES block in-place
+    #[inline]
+    fn encrypt(&self, block: &mut Block) {
+        self.cipher.encrypt(block.as_mut())
+    }
+}

--- a/rust/src/internals/block.rs
+++ b/rust/src/internals/block.rs
@@ -1,0 +1,143 @@
+//! `internals/block.rs`: Functions for working on cipher blocks.
+//!
+//! Special-cased for AES's 128-bit block size
+
+use super::util;
+use core::{mem, ptr};
+use subtle::{Equal, Mask};
+
+/// All constructions are presently specialized to a 128-bit block size (i.e. the AES block size)
+pub const SIZE: usize = 16;
+
+/// A block acceptable to pass to a block cipher (i.e. memory aligned)
+#[derive(Clone, Default)]
+#[repr(align(16))]
+pub struct Block([u8; SIZE]);
+
+impl Block {
+    /// Create a new block, initialized to zero
+    pub fn new() -> Block {
+        Block([0u8; SIZE])
+    }
+
+    /// XOR the other block into this one
+    #[inline]
+    pub fn xor_in_place<T>(&mut self, other: T)
+    where
+        T: AsRef<[u8]>,
+    {
+        // TODO: find a way to eliminate this assertion with type safety
+        assert_eq!(
+            other.as_ref().len(),
+            SIZE,
+            "xor_in_place works on block-sized slices"
+        );
+
+        let other_ref: &[u8; SIZE] = array_ref!(other.as_ref(), 0, SIZE);
+
+        if (other_ref.as_ptr() as usize) % SIZE == 0 {
+            // If the other value is aligned we can XOR directly
+            let x: &mut u128 = unsafe { mem::transmute(&mut self.0) };
+            let y: &u128 = unsafe { mem::transmute(other_ref) };
+
+            *x ^= *y;
+        } else {
+            // Fall back on a slower method if unaligned
+            util::xor_in_place(&mut self.0, other.as_ref());
+        }
+    }
+
+    /// Copy the contents of the other block into this one
+    ///
+    /// Panics if the two blocks are the same
+    #[inline]
+    pub fn copy_from_block(&mut self, other: &Block) {
+        assert_ne!(self.0.as_ptr(), other.0.as_ptr(), "can't copy self");
+        unsafe { ptr::copy_nonoverlapping(&other.0, &mut self.0, SIZE) }
+    }
+
+    /// Performs a doubling operation as defined in the CMAC and SIV papers
+    // TODO: use optimized implementation that assumes alignment
+    #[inline]
+    pub fn dbl(&mut self) {
+        util::dbl(&mut self.0);
+    }
+
+    /// Zero out the contents of the block
+    #[inline]
+    pub fn clear(&mut self) {
+        util::clear(&mut self.0);
+    }
+}
+
+impl From<[u8; SIZE]> for Block {
+    #[inline]
+    fn from(buf: [u8; SIZE]) -> Block {
+        Block(buf)
+    }
+}
+
+impl<'a> From<&'a [u8]> for Block {
+    #[inline]
+    fn from(buf: &[u8]) -> Block {
+        let len = buf.len();
+
+        if len > SIZE {
+            panic!("slice is too large for block! (size: {})", buf.len());
+        }
+
+        let mut block = Block::new();
+        block.0[..len].copy_from_slice(buf);
+        block
+    }
+}
+
+impl AsRef<[u8]> for Block {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8; SIZE]> for Block {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8; SIZE] {
+        &mut self.0
+    }
+}
+
+impl Drop for Block {
+    #[inline]
+    fn drop(&mut self) {
+        self.clear()
+    }
+}
+
+impl Equal for Block {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> Mask {
+        self.0.ct_eq(&other.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Block;
+
+    #[test]
+    fn test_xor_in_place() {
+        let mut block1 = Block::from(
+            *b"\x17\xcc\xf7\xf7\xa1\x8c\xbc\x3d\x8d\xad\0\xf1\xc9\x79\x9f\xba",
+        );
+
+        let block2 = Block::from(
+            *b"\x8d\xa8\xd5\x40\x7c\x9a\x62\xa0\x7b\x89\x94\x39\x3a\x84\xf1\x6b",
+        );
+
+        block1.xor_in_place(&block2);
+        assert_eq!(
+            block1.as_ref(),
+            b"\x9a\x64\x22\xb7\xdd\x16\xde\x9d\xf6\x24\x94\xc8\xf3\xfd\x6e\xd1"
+        );
+    }
+}

--- a/rust/src/internals/block_cipher.rs
+++ b/rust/src/internals/block_cipher.rs
@@ -1,0 +1,14 @@
+//! `internals/block_cipher.rs`: Trait for encrypting with different block ciphers.
+
+use super::Block;
+
+/// Common interface to a block cipher's raw block function
+///
+/// We implement only the encryption function as that's all that AES-SIV depends on
+pub trait BlockCipher: Clone {
+    /// Size of the key used by this cipher (in bytes)
+    const KEY_SIZE: usize;
+
+    /// Encrypt a block
+    fn encrypt(&self, block: &mut Block);
+}

--- a/rust/src/internals/cmac.rs
+++ b/rust/src/internals/cmac.rs
@@ -1,0 +1,118 @@
+//! `internals/cmac.rs`: Cipher-based Message Authentication Code
+
+use super::{Block, BlockCipher, BLOCK_SIZE};
+use super::util;
+
+type Tag = Block;
+
+/// Cipher-based Message Authentication Code
+pub struct Cmac<C: BlockCipher> {
+    cipher: C,
+    subkey1: Block,
+    subkey2: Block,
+    state: Block,
+    state_pos: usize,
+    finished: bool,
+}
+
+impl<C: BlockCipher> Cmac<C> {
+    /// Create a new CMAC instance with the given cipher
+    #[inline]
+    pub fn new(cipher: C) -> Self {
+        let mut subkey1 = Block::new();
+        cipher.encrypt(&mut subkey1);
+        subkey1.dbl();
+
+        let mut subkey2 = subkey1.clone();
+        subkey2.dbl();
+
+        Self {
+            subkey1: subkey1,
+            subkey2: subkey2,
+            state: Block::new(),
+            cipher: cipher,
+            state_pos: 0,
+            finished: false,
+        }
+    }
+
+    /// Reset a CMAC instance back to its initial state
+    #[inline]
+    pub fn reset(&mut self) {
+        self.state.clear();
+        self.state_pos = 0;
+        self.finished = false;
+    }
+
+    /// Update the CMAC state with the given message
+    ///
+    /// Panics if we're already in a finished state (must reset before reusing)
+    pub fn update(&mut self, msg: &[u8]) {
+        if self.finished {
+            panic!("already finished");
+        }
+
+        let mut msg_pos: usize = 0;
+        let mut msg_len: usize = msg.len();
+        let remaining = BLOCK_SIZE - self.state_pos;
+
+        if msg_len > remaining {
+            util::xor_in_place(
+                &mut self.state.as_mut()[self.state_pos..],
+                &msg[..remaining],
+            );
+
+            msg_len = msg_len.checked_sub(remaining).expect("underflow");
+            msg_pos = msg_pos.checked_add(remaining).expect("overflow");
+
+            self.cipher.encrypt(&mut self.state);
+            self.state_pos = 0;
+        }
+
+        while msg_len > BLOCK_SIZE {
+            self.state.xor_in_place(
+                array_ref!(msg, msg_pos, BLOCK_SIZE),
+            );
+
+            msg_len = msg_len.checked_sub(BLOCK_SIZE).expect("underflow");
+            msg_pos = msg_pos.checked_add(BLOCK_SIZE).expect("overflow");
+
+            self.cipher.encrypt(&mut self.state);
+        }
+
+        if msg_len > 0 {
+            let state_end = self.state_pos.checked_add(msg_len).expect("overflow");
+
+            util::xor_in_place(
+                &mut self.state.as_mut()[self.state_pos..state_end],
+                &msg[msg_pos..msg_pos.checked_add(msg_len).expect("overflow")],
+            );
+
+            self.state_pos = self.state_pos.checked_add(msg_len).expect("overflow");
+        }
+    }
+
+    /// Finish computing CMAC, returning the computed tag
+    ///
+    /// Panics if we're already in a finished state (must reset before reusing)
+    pub fn finish(&mut self) -> Tag {
+        if self.finished {
+            panic!("already finished");
+        }
+
+        if self.state_pos == BLOCK_SIZE {
+            self.state.xor_in_place(&self.subkey1);
+        } else {
+            self.state.xor_in_place(&self.subkey2);
+        };
+
+        if self.state_pos < BLOCK_SIZE {
+            self.state.as_mut()[self.state_pos] ^= 0x80;
+        }
+
+        self.cipher.encrypt(&mut self.state);
+        self.finished = true;
+
+        self.state.clone()
+    }
+}

--- a/rust/src/internals/ctr.rs
+++ b/rust/src/internals/ctr.rs
@@ -1,0 +1,46 @@
+//! `internals/ctr.rs`: Counter Mode encryption/decryption
+
+use super::{BLOCK_SIZE, Block, BlockCipher};
+use super::util;
+
+/// Counter Mode encryption/decryption
+pub struct Ctr<C: BlockCipher> {
+    cipher: C,
+    buffer: Block,
+    buffer_pos: usize,
+}
+
+impl<C: BlockCipher> Ctr<C> {
+    /// Create a new CTR instance with the given cipher
+    #[inline]
+    pub fn new(cipher: C) -> Self {
+        Self {
+            cipher: cipher,
+            buffer: Block::new(),
+            buffer_pos: BLOCK_SIZE,
+        }
+    }
+
+    /// Reset the internal cipher state back to its initial values
+    pub fn reset(&mut self) {
+        self.buffer.clear();
+        self.buffer_pos = BLOCK_SIZE;
+    }
+
+    /// Encrypt/decrypt the given data in-place, updating the internal cipher state
+    ///
+    /// Accepts a mutable counter value, which is also updated in-place
+    pub fn transform(&mut self, counter: &mut Block, data: &mut [u8]) {
+        for b in data {
+            if self.buffer_pos == BLOCK_SIZE {
+                self.buffer.copy_from_block(counter);
+                self.cipher.encrypt(&mut self.buffer);
+                self.buffer_pos = 0;
+                util::ctr_increment(counter.as_mut());
+            }
+
+            *b ^= self.buffer.as_ref()[self.buffer_pos];
+            self.buffer_pos = self.buffer_pos.checked_add(1).expect("overflow");
+        }
+    }
+}

--- a/rust/src/internals/mod.rs
+++ b/rust/src/internals/mod.rs
@@ -1,0 +1,15 @@
+//! `internals/mod.rs`: Low-level cryptographic functions not intended for public use
+
+mod aes;
+mod block;
+pub mod block_cipher;
+mod cmac;
+mod ctr;
+pub mod util;
+
+pub use self::aes::{Aes128, Aes256};
+pub use self::block::Block;
+pub use self::block::SIZE as BLOCK_SIZE;
+pub use self::block_cipher::BlockCipher;
+pub use self::cmac::Cmac;
+pub use self::ctr::Ctr;

--- a/rust/src/internals/util/dbl.asm
+++ b/rust/src/internals/util/dbl.asm
@@ -1,0 +1,14 @@
+mov rax, qword ptr [rdi]
+mov rcx, qword ptr [rdi + 8]
+bswap rcx
+bswap rax
+mov rdx, rax
+shld rdx, rcx, 1
+add rcx, rcx
+sar rax, 63
+and eax, 135
+xor rax, rcx
+bswap rax
+bswap rdx
+mov qword ptr [rdi], rdx
+mov qword ptr [rdi + 8], rax

--- a/rust/src/internals/util/dbl.rs
+++ b/rust/src/internals/util/dbl.rs
@@ -1,0 +1,16 @@
+//! `internals/util/dbl.rs`: Reference implementation of dbl()
+//!
+//! This implementation is not guaranteed to be constant time, so we first compile it for a
+//! particular architecture and then verify the generated assembly.
+//!
+//! See `dbl.asm` for the generated output.
+
+use byteorder::{BigEndian, ByteOrder};
+use super::BLOCK_SIZE;
+
+/// Perform a doubling operation
+pub fn dbl(value: &mut [u8; BLOCK_SIZE]) {
+    let input = BigEndian::read_u128(value);
+    let output = (input << 1) ^ (input >> 127) * 0b10000111;
+    BigEndian::write_u128(value, output);
+}

--- a/rust/src/internals/util/mod.rs
+++ b/rust/src/internals/util/mod.rs
@@ -1,0 +1,76 @@
+//! `internals/util/mod.rs`: Utility functions
+
+use super::BLOCK_SIZE;
+use byteorder::{BigEndian, ByteOrder};
+use core::intrinsics;
+
+/// Zero out the given slice
+#[inline]
+pub fn clear(value: &mut [u8]) {
+    unsafe {
+        // TODO: use a crate that provides this (e.g. clear_on_drop) instead of intrinsics
+        intrinsics::volatile_set_memory(value.as_mut_ptr(), 0, value.len())
+    }
+}
+
+/// Increment a CTR-mode counter. Panics on overflow
+// TODO: use verified asm implementation?
+pub fn ctr_increment(value: &mut [u8; BLOCK_SIZE]) {
+    // This intentionally uses wrapping arithmetic as this is the correct
+    // behavior for counter overflows.
+    // TODO: verify we wrap at 128-bits and add test vectors which exercise it
+    let output = BigEndian::read_u128(value) + 1;
+    BigEndian::write_u128(value, output);
+}
+
+/// Perform an in-place doubling operation
+#[inline]
+pub fn dbl(value: &mut [u8; BLOCK_SIZE]) {
+    unsafe {
+        asm!(include_str!("dbl.asm")
+            :
+            : "rdi"(value)
+            : "rax", "rcx", "rdx", "eax", "memory"
+            : "intel"
+        )
+    }
+}
+
+/// XOR the second argument into the first in-place. Slices do not have to be
+/// aligned in memory.
+///
+/// Panics if the two slices aren't the same length
+pub fn xor_in_place(a: &mut [u8], b: &[u8]) {
+    assert_eq!(a.len(), b.len(), "slices are not the same length!");
+
+    for (b1, b2) in a.iter_mut().zip(b.iter()) {
+        *b1 ^= *b2;
+    }
+}
+
+/// Zero out the top bits in the last 32-bit words of the IV
+pub fn zero_iv_bits(iv: &mut [u8; BLOCK_SIZE]) {
+    let len = iv.len();
+
+    // "We zero-out the top bit in each of the last two 32-bit words
+    // of the IV before assigning it to Ctr"
+    //  — http://web.cs.ucdavis.edu/~rogaway/papers/siv.pdf
+    iv[len - 8] &= 0x7f;
+    iv[len - 4] &= 0x7f;
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn counter_increment() {
+        let mut buffer = [0u8; 16];
+        super::ctr_increment(&mut buffer);
+        assert_eq!(buffer, *b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01");
+    }
+
+    #[test]
+    #[should_panic]
+    fn counter_overflow() {
+        super::ctr_increment(&mut [0xFFu8; 16]);
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,29 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {}
-}
+//! `Miscreant`: Misuse-resistant symmetric encryption using the AES-SIV (RFC 5297) and
+//! CHAIN/STREAM constructions.
+
+#![crate_name = "miscreant"]
+#![crate_type = "lib"]
+
+#![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
+#![deny(unused_import_braces, unused_qualifications)]
+
+#![no_std]
+
+// Experimental features
+// TODO: make crate work on stable
+#![feature(i128_type)]
+#![feature(asm)]
+#![feature(attr_literals)]
+#![feature(core_intrinsics)]
+#![feature(repr_align)]
+
+#[macro_use]
+extern crate arrayref;
+extern crate byteorder;
+extern crate subtle;
+
+// TODO: reduce visibility by gating it on e.g. #[cfg(debug_assertions)]
+pub mod internals;
+pub mod siv;
+
+pub use siv::{Aes128Siv, Aes256Siv};

--- a/rust/src/siv.rs
+++ b/rust/src/siv.rs
@@ -1,0 +1,196 @@
+//! `siv.rs`: The SIV misuse resistant block cipher mode of operation
+
+use core::ptr;
+
+use internals::{Aes128, Aes256};
+use internals::{BLOCK_SIZE, Block, BlockCipher, Cmac, Ctr};
+use internals::util;
+use subtle::Equal;
+
+/// Maximum number of associated data items
+pub const MAX_ASSOCIATED_DATA: usize = 126;
+
+/// A block of all zeroes
+pub const ZERO_BLOCK: &[u8; BLOCK_SIZE] = &[0u8; BLOCK_SIZE];
+
+/// A SIV tag
+type Tag = Block;
+
+/// The SIV misuse resistant block cipher mode of operation
+pub struct Siv<C: BlockCipher> {
+    mac: Cmac<C>,
+    ctr: Ctr<C>,
+}
+
+/// AES-SIV with a 128-bit key
+pub type Aes128Siv = Siv<Aes128>;
+
+impl Aes128Siv {
+    /// Create a new AES-SIV instance with a 32-byte key
+    pub fn new(key: &[u8; 32]) -> Self {
+        Self {
+            mac: Cmac::new(Aes128::new(array_ref!(key, 0, 16))),
+            ctr: Ctr::new(Aes128::new(array_ref!(key, 16, 16))),
+        }
+    }
+}
+
+/// AES-SIV with a 256-bit key
+pub type Aes256Siv = Siv<Aes256>;
+
+impl Aes256Siv {
+    /// Create a new AES-SIV instance with a 32-byte key
+    pub fn new(key: &[u8; 64]) -> Self {
+        Self {
+            mac: Cmac::new(Aes256::new(array_ref!(key, 0, 32))),
+            ctr: Ctr::new(Aes256::new(array_ref!(key, 32, 32))),
+        }
+    }
+}
+
+impl<C: BlockCipher> Siv<C> {
+    /// Encrypt the given plaintext in-place, replacing it with the SIV tag and
+    /// ciphertext. Requires a buffer with 16-bytes additional space.
+    ///
+    /// # Usage
+    ///
+    /// It's important to note that only the beginning of the buffer will be
+    /// treated as the input plaintext:
+    ///
+    /// ```rust
+    /// let buffer = [0u8; 21];
+    /// let plaintext = &buffer[..buffer.len() - 16];
+    /// ```
+    ///
+    /// In this case, only the first 5 bytes are treated as the plaintext,
+    /// since `21 - 16 = 5` (the AES block size is 16-bytes).
+    ///
+    /// The buffer must include an additional 16-bytes of space in which to
+    /// write the SIV tag (at the beginning of the buffer).
+    /// Failure to account for this will leave you with plaintext messages that
+    /// are missing their last 16-bytes!
+    ///
+    /// # Panics
+    ///
+    /// Panics if `plaintext.len()` is less than `BLOCK_SIZE`.
+    /// Panics if `associated_data.len()` is greater than `MAX_ASSOCIATED_DATA`.
+    pub fn seal_in_place<I, T>(&mut self, associated_data: I, plaintext: &mut [u8])
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<[u8]>,
+    {
+        if plaintext.len() < BLOCK_SIZE {
+            panic!("plaintext buffer too small to hold SIV tag!");
+        }
+
+        let len = plaintext.len().checked_sub(BLOCK_SIZE).unwrap();
+
+        unsafe {
+            ptr::copy(
+                plaintext.as_ptr(),
+                plaintext[BLOCK_SIZE..].as_mut_ptr(),
+                len,
+            );
+        }
+
+        // Compute the synthetic IV for this plaintext
+        let mut iv = self.s2v(associated_data, &plaintext[BLOCK_SIZE..]);
+        plaintext[..BLOCK_SIZE].copy_from_slice(iv.as_ref());
+
+        util::zero_iv_bits(iv.as_mut());
+        self.ctr.transform(&mut iv, &mut plaintext[BLOCK_SIZE..]);
+        self.ctr.reset();
+    }
+
+    /// Decrypt the given ciphertext in-place, authenticating it against the
+    /// synthetic IV included in the message.
+    pub fn open_in_place<'a, I, T>(
+        &mut self,
+        associated_data: I,
+        ciphertext: &'a mut [u8],
+    ) -> Result<&'a [u8], ()>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<[u8]>,
+    {
+        if ciphertext.len() < BLOCK_SIZE {
+            return Err(());
+        }
+
+        let mut iv = Block::from(&ciphertext[..BLOCK_SIZE]);
+        util::zero_iv_bits(iv.as_mut());
+
+        self.ctr.transform(&mut iv, &mut ciphertext[BLOCK_SIZE..]);
+        self.ctr.reset();
+
+        let actual_tag = self.s2v(associated_data, &ciphertext[BLOCK_SIZE..]);
+
+        if actual_tag.ct_eq(&Block::from(&ciphertext[..BLOCK_SIZE])) != 1 {
+            let mut iv = Block::from(&ciphertext[..BLOCK_SIZE]);
+
+            // Re-encrypt the decrypted plaintext to avoid revealing it
+            self.ctr.transform(&mut iv, &mut ciphertext[BLOCK_SIZE..]);
+            self.ctr.reset();
+
+            return Err(());
+        }
+
+        let len = ciphertext.len().checked_sub(BLOCK_SIZE).unwrap();
+
+        unsafe {
+            ptr::copy(
+                ciphertext[BLOCK_SIZE..].as_ptr(),
+                ciphertext.as_mut_ptr(),
+                len,
+            );
+        }
+
+        Ok(&ciphertext[..len])
+    }
+
+    /// The S2V operation consists of the doubling and XORing of the outputs
+    /// of the pseudo-random function CMAC.
+    ///
+    /// See Section 2.4 of RFC 5297 for more information
+    fn s2v<I, T>(&mut self, associated_data: I, plaintext: &[u8]) -> Tag
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<[u8]>,
+    {
+        self.mac.reset();
+        self.mac.update(ZERO_BLOCK);
+        let mut state = self.mac.finish();
+
+        for (i, ad) in associated_data.into_iter().enumerate() {
+            if i >= MAX_ASSOCIATED_DATA {
+                panic!("too many associated data items!");
+            }
+
+            self.mac.reset();
+            self.mac.update(ad.as_ref());
+
+            state.dbl();
+            state.xor_in_place(&self.mac.finish());
+        }
+
+        self.mac.reset();
+
+        if plaintext.len() >= BLOCK_SIZE {
+            let n = plaintext.len().checked_sub(BLOCK_SIZE).unwrap();
+            self.mac.update(&plaintext[..n]);
+            state.xor_in_place(array_ref!(plaintext, n, BLOCK_SIZE));
+        } else {
+            let mut tmp = Block::from(plaintext);
+            tmp.as_mut()[plaintext.len()] = 0x80;
+
+            state.dbl();
+            state.xor_in_place(&tmp);
+        };
+
+        self.mac.update(state.as_ref());
+        let result = self.mac.finish();
+        self.mac.reset();
+
+        result
+    }
+}

--- a/rust/tests/lib.rs
+++ b/rust/tests/lib.rs
@@ -1,0 +1,146 @@
+#[macro_use]
+extern crate arrayref;
+extern crate miscreant;
+
+use miscreant::{Aes128Siv, Aes256Siv};
+use miscreant::internals::{Aes128, Aes256, Block, BlockCipher, Cmac, Ctr, util};
+use miscreant::internals::BLOCK_SIZE;
+
+mod test_vectors;
+use test_vectors::{AesExample, AesCmacExample, AesCtrExample, AesSivExample, DblExample};
+
+#[test]
+fn aes_examples() {
+    let examples = AesExample::load_all();
+
+    for example in examples {
+        let mut block = Block::new();
+        block.as_mut().copy_from_slice(&example.src);
+
+        match example.key.len() {
+            16 => {
+                let aes = Aes128::new(array_ref!(example.key, 0, 16));
+                aes.encrypt(&mut block);
+            }
+            32 => {
+                let aes = Aes256::new(array_ref!(example.key, 0, 32));
+                aes.encrypt(&mut block);
+            }
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        }
+
+        assert_eq!(block.as_ref(), array_ref!(example.dst, 0, 16));
+    }
+}
+
+#[test]
+fn aes_cmac_examples() {
+    let examples = AesCmacExample::load_all();
+
+    for example in examples {
+        let result = match example.key.len() {
+            16 => {
+                let aes = Aes128::new(array_ref!(example.key, 0, 16));
+                let mut aes_cmac = Cmac::new(aes);
+
+                aes_cmac.update(&example.message);
+                aes_cmac.finish()
+            }
+            32 => {
+                let aes = Aes256::new(array_ref!(example.key, 0, 32));
+                let mut aes_cmac = Cmac::new(aes);
+
+                aes_cmac.update(&example.message);
+                aes_cmac.finish()
+            }
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        };
+
+        assert_eq!(result.as_ref(), array_ref!(example.tag, 0, 16));
+    }
+}
+
+#[test]
+fn aes_ctr_examples() {
+    let examples = AesCtrExample::load_all();
+
+    for example in examples {
+        let mut buffer = example.plaintext.clone();
+
+        match example.key.len() {
+            16 => {
+                let aes = Aes128::new(array_ref!(example.key, 0, 16));
+                let mut aes_ctr = Ctr::new(aes);
+                let mut iv = Block::from(&example.iv[..]);
+                aes_ctr.transform(&mut iv, &mut buffer);
+            }
+            32 => {
+                let aes = Aes256::new(array_ref!(example.key, 0, 32));
+                let mut aes_ctr = Ctr::new(aes);
+                let mut iv = Block::from(&example.iv[..]);
+                aes_ctr.transform(&mut iv, &mut buffer);
+            }
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        };
+
+        assert_eq!(buffer, example.ciphertext);
+    }
+}
+
+#[test]
+fn aes_siv_examples_seal() {
+    let examples = AesSivExample::load_all();
+
+    for example in examples {
+        let len = example.plaintext.len();
+        let mut buffer = vec![0; len + BLOCK_SIZE];
+        buffer[..len].copy_from_slice(&example.plaintext);
+
+        match example.key.len() {
+            32 => {
+                let mut siv = Aes128Siv::new(array_ref!(example.key, 0, 32));
+                siv.seal_in_place(&example.ad, &mut buffer);
+            }
+            64 => {
+                let mut siv = Aes256Siv::new(array_ref!(example.key, 0, 64));
+                siv.seal_in_place(&example.ad, &mut buffer);
+            }
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        };
+
+        assert_eq!(buffer, example.ciphertext);
+    }
+}
+
+#[test]
+fn aes_siv_examples_open() {
+    let examples = AesSivExample::load_all();
+
+    for example in examples {
+        let mut buffer = example.ciphertext.clone();
+
+        let plaintext = match example.key.len() {
+            32 => {
+                let mut siv = Aes128Siv::new(array_ref!(example.key, 0, 32));
+                siv.open_in_place(&example.ad, &mut buffer)
+            }
+            64 => {
+                let mut siv = Aes256Siv::new(array_ref!(example.key, 0, 64));
+                siv.open_in_place(&example.ad, &mut buffer)
+            }
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        }.expect("successful decrypt");
+
+        assert_eq!(plaintext, &example.plaintext[..]);
+    }
+}
+
+#[test]
+fn dbl_examples() {
+    let examples = DblExample::load_all();
+    for example in examples {
+        let mut value = *array_ref!(example.input, 0, 16);
+        util::dbl(&mut value);
+        assert_eq!(value, *array_ref!(example.output, 0, 16));
+    }
+}

--- a/rust/tests/test_vectors.rs
+++ b/rust/tests/test_vectors.rs
@@ -1,0 +1,294 @@
+extern crate data_encoding;
+extern crate serde_json;
+
+use self::data_encoding::HEXLOWER;
+pub use self::serde_json::Value as JsonValue;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+/// AES block cipher test vectors
+// TODO: switch to the tjson crate (based on serde)
+#[derive(Debug)]
+pub struct AesExample {
+    pub key: Vec<u8>,
+    pub src: Vec<u8>,
+    pub dst: Vec<u8>,
+}
+
+impl AesExample {
+    /// Load examples from aes.tjson
+    pub fn load_all() -> Vec<Self> {
+        Self::load_from_file(Path::new("../vectors/aes.tjson"))
+    }
+
+    /// Load examples from a file at the given path
+    pub fn load_from_file(path: &Path) -> Vec<Self> {
+        let mut file = File::open(&path).expect("valid aes.tjson");
+        let mut tjson_string = String::new();
+        file.read_to_string(&mut tjson_string).expect(
+            "aes.tjson read successfully",
+        );
+
+        let tjson: serde_json::Value =
+            serde_json::from_str(&tjson_string).expect("aes.tjson parses successfully");
+        let examples = &tjson["examples:A<O>"].as_array().expect(
+            "aes.tjson examples array",
+        );
+
+        examples
+            .into_iter()
+            .map(|ex| {
+                Self {
+                    key: HEXLOWER
+                        .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                        .expect("hex encoded"),
+                    src: HEXLOWER
+                        .decode(ex["src:d16"].as_str().expect("encoded example").as_bytes())
+                        .expect("hex encoded"),
+                    dst: HEXLOWER
+                        .decode(ex["dst:d16"].as_str().expect("encoded example").as_bytes())
+                        .expect("hex encoded"),
+                }
+            })
+            .collect()
+    }
+}
+
+/// AES-CMAC test vectors
+// TODO: switch to the tjson crate (based on serde)
+#[derive(Debug)]
+pub struct AesCmacExample {
+    pub key: Vec<u8>,
+    pub message: Vec<u8>,
+    pub tag: Vec<u8>,
+}
+
+impl AesCmacExample {
+    /// Load examples from aes_cmac.tjson
+    pub fn load_all() -> Vec<Self> {
+        Self::load_from_file(Path::new("../vectors/aes_cmac.tjson"))
+    }
+
+    /// Load examples from a file at the given path
+    pub fn load_from_file(path: &Path) -> Vec<Self> {
+        let mut file = File::open(&path).expect("valid aes_cmac.tjson");
+        let mut tjson_string = String::new();
+        file.read_to_string(&mut tjson_string).expect(
+            "aes_cmac.tjson read successfully",
+        );
+
+        let tjson: serde_json::Value =
+            serde_json::from_str(&tjson_string).expect("aes_cmac.tjson parses successfully");
+        let examples = &tjson["examples:A<O>"].as_array().expect(
+            "aes_cmac.tjson examples array",
+        );
+
+        examples
+            .into_iter()
+            .map(|ex| {
+                Self {
+                    key: HEXLOWER
+                        .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                        .expect("hex encoded"),
+                    message: HEXLOWER
+                        .decode(
+                            ex["message:d16"]
+                                .as_str()
+                                .expect("encoded example")
+                                .as_bytes(),
+                        )
+                        .expect("hex encoded"),
+                    tag: HEXLOWER
+                        .decode(ex["tag:d16"].as_str().expect("encoded example").as_bytes())
+                        .expect("hex encoded"),
+                }
+            })
+            .collect()
+    }
+}
+
+/// AES-CTR test vectors
+// TODO: switch to the tjson crate (based on serde)
+#[derive(Debug)]
+pub struct AesCtrExample {
+    pub key: Vec<u8>,
+    pub iv: Vec<u8>,
+    pub plaintext: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+}
+
+impl AesCtrExample {
+    /// Load examples from aes_ctr.tjson
+    pub fn load_all() -> Vec<Self> {
+        Self::load_from_file(Path::new("../vectors/aes_ctr.tjson"))
+    }
+
+    /// Load examples from a file at the given path
+    pub fn load_from_file(path: &Path) -> Vec<Self> {
+        let mut file = File::open(&path).expect("valid aes_ctr.tjson");
+        let mut tjson_string = String::new();
+        file.read_to_string(&mut tjson_string).expect(
+            "aes_ctr.tjson read successfully",
+        );
+
+        let tjson: serde_json::Value =
+            serde_json::from_str(&tjson_string).expect("aes_ctr.tjson parses successfully");
+        let examples = &tjson["examples:A<O>"].as_array().expect(
+            "aes_ctr.tjson examples array",
+        );
+
+        examples
+            .into_iter()
+            .map(|ex| {
+                Self {
+                    key: HEXLOWER
+                        .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                        .expect("hex encoded"),
+                    iv: HEXLOWER
+                        .decode(ex["iv:d16"].as_str().expect("encoded example").as_bytes())
+                        .expect("hex encoded"),
+                    plaintext: HEXLOWER
+                        .decode(
+                            ex["plaintext:d16"]
+                                .as_str()
+                                .expect("encoded example")
+                                .as_bytes(),
+                        )
+                        .expect("hex encoded"),
+                    ciphertext: HEXLOWER
+                        .decode(
+                            ex["ciphertext:d16"]
+                                .as_str()
+                                .expect("encoded example")
+                                .as_bytes(),
+                        )
+                        .expect("hex encoded"),
+                }
+            })
+            .collect()
+    }
+}
+
+/// AES-SIV test vectors
+// TODO: switch to the tjson crate (based on serde)
+#[derive(Debug)]
+pub struct AesSivExample {
+    pub key: Vec<u8>,
+    pub ad: Vec<Vec<u8>>,
+    pub plaintext: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+}
+
+impl AesSivExample {
+    /// Load examples from aes_siv.tjson
+    pub fn load_all() -> Vec<Self> {
+        Self::load_from_file(Path::new("../vectors/aes_siv.tjson"))
+    }
+
+    /// Load examples from a file at the given path
+    pub fn load_from_file(path: &Path) -> Vec<Self> {
+        let mut file = File::open(&path).expect("valid aes_siv.tjson");
+        let mut tjson_string = String::new();
+        file.read_to_string(&mut tjson_string).expect(
+            "aes_siv.tjson read successfully",
+        );
+
+        let tjson: serde_json::Value =
+            serde_json::from_str(&tjson_string).expect("aes_siv.tjson parses successfully");
+        let examples = &tjson["examples:A<O>"].as_array().expect(
+            "aes_siv.tjson examples array",
+        );
+
+        examples
+            .into_iter()
+            .map(|ex| {
+                Self {
+                    key: HEXLOWER
+                        .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                        .expect("hex encoded"),
+                    ad: ex["ad:A<d16>"]
+                        .as_array()
+                        .expect("encoded example")
+                        .iter()
+                        .map(|ex| {
+                            HEXLOWER
+                                .decode(ex.as_str().expect("encoded example").as_bytes())
+                                .expect("hex encoded")
+                        })
+                        .collect(),
+                    plaintext: HEXLOWER
+                        .decode(
+                            ex["plaintext:d16"]
+                                .as_str()
+                                .expect("encoded example")
+                                .as_bytes(),
+                        )
+                        .expect("hex encoded"),
+                    ciphertext: HEXLOWER
+                        .decode(
+                            ex["ciphertext:d16"]
+                                .as_str()
+                                .expect("encoded example")
+                                .as_bytes(),
+                        )
+                        .expect("hex encoded"),
+                }
+            })
+            .collect()
+    }
+}
+
+/// dbl() test vectors
+// TODO: switch to the tjson crate (based on serde)
+#[derive(Debug)]
+pub struct DblExample {
+    pub input: Vec<u8>,
+    pub output: Vec<u8>,
+}
+
+impl DblExample {
+    /// Load examples from dbl.tjson
+    pub fn load_all() -> Vec<Self> {
+        Self::load_from_file(Path::new("../vectors/dbl.tjson"))
+    }
+
+    /// Load examples from a file at the given path
+    pub fn load_from_file(path: &Path) -> Vec<Self> {
+        let mut file = File::open(&path).expect("valid dbl.tjson");
+        let mut tjson_string = String::new();
+        file.read_to_string(&mut tjson_string).expect(
+            "dbl.tjson read successfully",
+        );
+
+        let tjson: serde_json::Value =
+            serde_json::from_str(&tjson_string).expect("dbl.tjson parses successfully");
+        let examples = &tjson["examples:A<O>"].as_array().expect(
+            "dbl.tjson examples array",
+        );
+
+        examples
+            .into_iter()
+            .map(|ex| {
+                Self {
+                    input: HEXLOWER
+                        .decode(
+                            ex["input:d16"]
+                                .as_str()
+                                .expect("encoded example")
+                                .as_bytes(),
+                        )
+                        .expect("hex encoded"),
+                    output: HEXLOWER
+                        .decode(
+                            ex["output:d16"]
+                                .as_str()
+                                .expect("encoded example")
+                                .as_bytes(),
+                        )
+                        .expect("hex encoded"),
+                }
+            })
+            .collect()
+    }
+}

--- a/vectors/aes_ctr.tjson
+++ b/vectors/aes_ctr.tjson
@@ -1,6 +1,12 @@
 {
     "examples:A<O>":[
         {
+            "key:d16":"2b7e151628aed2a6abf7158809cf4f3c",
+            "iv:d16":"f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+            "plaintext:d16":"6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+            "ciphertext:d16":"874d6191b620e3261bef6864990db6ce9806f66b7970fdff8617187bb9fffdff"
+        },
+        {
             "key:d16":"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
             "iv:d16":"202122232425262728292a2b2c2d2e2f",
             "plaintext:d16":"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122",


### PR DESCRIPTION
This commit implements AES-CMAC, AES-CTR, and AES-SIV using the `aesni` crate.

The implementation presently only works on nightly, and leverages a number of nightly features including inline assembly, intrinisics, and `repr_align` to ensure alignment of blocks in memory.