### PR TITLE
Revert "rust: Downgrade subtle crate to 0.1.0"

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.0.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -63,11 +63,8 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [metadata]
 "checksum aesni 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "341c18a4ead1b3e3858e013473455dd24df63118308e548b9796187f17ab5ba7"
@@ -79,4 +76,4 @@ dependencies = [
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"
 "checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
-"checksum subtle 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b811576c12506ff3f6da145585dc833edc32ee34c9fc021127d90e8134cc05c"
+"checksum subtle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32dbfc4beea0a08bfe33114d0f5e5092f35f6fa387a955b4a2c68888cdd7b0f2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,7 +14,7 @@ keywords    = ["cryptography", "encryption", "security", "streaming"]
 aesni = "0.1"
 arrayref = "0.3"
 byteorder = { version = "1.1", default-features = false, features = ["i128"] }
-subtle = "= 0.1"
+subtle = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 data-encoding = "2.0.0-rc.1"

--- a/rust/src/internals/block.rs
+++ b/rust/src/internals/block.rs
@@ -1,10 +1,9 @@
-//! `internals/block.rs`: Functions for working on cipher blocks.
-//!
-//! Special-cased for AES's 128-bit block size
+//! `internals/block.rs`: Functions for working on cipher blocks. Special-cased for
+//! AES's 128-bit block size.
 
 use byteorder::{BigEndian, NativeEndian, ByteOrder};
 use core::{intrinsics, ptr};
-use subtle::{self, CTEq, Mask};
+use subtle::{Equal, Mask};
 
 /// All constructions are presently specialized to a 128-bit block size (i.e. the AES block size)
 pub const SIZE: usize = 16;
@@ -109,10 +108,10 @@ impl Drop for Block {
     }
 }
 
-impl CTEq for Block {
+impl Equal for Block {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Mask {
-        subtle::arrays_equal(&self.0, &other.0)
+        self.0.ct_eq(&other.0)
     }
 }
 

--- a/rust/src/siv.rs
+++ b/rust/src/siv.rs
@@ -4,7 +4,7 @@ use core::ptr;
 
 use internals::{Aes128, Aes256};
 use internals::{BLOCK_SIZE, Block, BlockCipher, Cmac, Ctr};
-use subtle::CTEq;
+use subtle::Equal;
 
 /// Maximum number of associated data items
 pub const MAX_ASSOCIATED_DATA: usize = 126;


### PR DESCRIPTION
Upgrades subtle to version 0.2.0.

This reverts commit 6608c03f90f152da251773baffdbcc0bd6b44432.