### PR TITLE
rust: Avoid needless copying

### DIFF
--- a/rust/tests/lib.rs
+++ b/rust/tests/lib.rs
@@ -94,7 +94,7 @@ fn aes_siv_examples_seal() {
     for example in examples {
         let len = example.plaintext.len();
         let mut buffer = vec![0; len + BLOCK_SIZE];
-        buffer[..len].copy_from_slice(&example.plaintext);
+        buffer[BLOCK_SIZE..].copy_from_slice(&example.plaintext);
 
         match example.key.len() {
             32 => {


### PR DESCRIPTION
Previously the `seal_in_place()`/`open_in_place()` functions copied the plaintext to/from the beginning/end of the buffer.

Instead we can simply make the API contract to place the plaintext at the end of the buffer so we can avoid copying it.