### PR TITLE
rust: Remove all unsafe code

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "aesni 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clear_on_drop 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.0.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -26,6 +27,14 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "clear_on_drop"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +42,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "dtoa"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gcc"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -70,8 +84,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aesni 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "341c18a4ead1b3e3858e013473455dd24df63118308e548b9796187f17ab5ba7"
 "checksum arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd1479b7c29641adbd35ff3b5c293922d696a92f25c8c975da3e0acbc87258f"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
+"checksum clear_on_drop 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1eac88fdd670f1056eea6c7a07b1fec002b9997e153bd9a142db6956c3c00e91"
 "checksum data-encoding 2.0.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c48768b270ab6458e2fba295bd3593f76d22058945afb5bdc6a1b1436511402b"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
+"checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,6 +14,7 @@ keywords    = ["cryptography", "encryption", "security", "streaming"]
 aesni = "0.1"
 arrayref = "0.3"
 byteorder = { version = "1.1", default-features = false, features = ["i128"] }
+clear_on_drop = { version = "0.2", features = ["nightly"] }
 subtle = { version = "0.2", default-features = false }
 
 [dev-dependencies]

--- a/rust/README.md
+++ b/rust/README.md
@@ -55,9 +55,6 @@ humans that make mistakes.
 
 This library makes an effort to use constant time operations throughout its
 implementation, however actual constant time behavior has not been verified.
-Furthermore to accomplish this, unsafe Rust features including inline assembly
-have been used. The correct operation of this unsafe code has not been
-thoroughly reviewed.
 
 Use this library at your own risk.
 

--- a/rust/src/internals/cmac.rs
+++ b/rust/src/internals/cmac.rs
@@ -2,6 +2,7 @@
 
 use super::{Block, BlockCipher, BLOCK_SIZE};
 use super::xor;
+use clear_on_drop::clear::Clear;
 
 type Tag = Block;
 

--- a/rust/src/internals/ctr.rs
+++ b/rust/src/internals/ctr.rs
@@ -2,6 +2,7 @@
 
 use super::{Block, BlockCipher, BLOCK_SIZE};
 use byteorder::{BigEndian, ByteOrder};
+use clear_on_drop::clear::Clear;
 
 /// Counter Mode encryption/decryption
 pub struct Ctr<C: BlockCipher> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,12 +14,12 @@
 #![feature(i128_type)]
 #![feature(asm)]
 #![feature(attr_literals)]
-#![feature(core_intrinsics)]
 #![feature(repr_align)]
 
 #[macro_use]
 extern crate arrayref;
 extern crate byteorder;
+extern crate clear_on_drop;
 extern crate subtle;
 
 // TODO: reduce visibility by gating it on e.g. #[cfg(debug_assertions)]


### PR DESCRIPTION
Following in the footsteps of #42, this commit removes any remaining unsafe code in the implementation, replacing it with safe code or third-party crates which wrap up unsafe functionality for us.

Use of any unsafe code should have a concrete justification, e.g. ensuring constant time operation or significant performance improvements.

Unfortunately, we can't actually `#[deny(unsafe_code)]` because the `array_ref!` crate generates some. Hopefully with future type system improvements we can get rid of `array_ref!` and actually turn on `#[deny(unsafe_code)]`.