### PR TITLE
rust: Add benchmarks which compare to *ring* AES-128-GCM

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2,23 +2,29 @@
 name = "miscreant"
 version = "0.1.0"
 dependencies = [
- "aesni 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aesni 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.0.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "arrayref"
 version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -35,6 +41,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "coco"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "data-encoding"
 version = "2.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +70,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "dtoa"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "either"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -55,8 +93,90 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "magenta"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "magenta-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ring"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scopeguard"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -80,16 +200,38 @@ name = "subtle"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "untrusted"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
-"checksum aesni 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "341c18a4ead1b3e3858e013473455dd24df63118308e548b9796187f17ab5ba7"
+"checksum aesni 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5874e2ee059599749030718fe61af059c22ff4fce4fa0367923a6733f9b99e9"
 "checksum arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd1479b7c29641adbd35ff3b5c293922d696a92f25c8c975da3e0acbc87258f"
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum clear_on_drop 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1eac88fdd670f1056eea6c7a07b1fec002b9997e153bd9a142db6956c3c00e91"
+"checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
+"checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+"checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum data-encoding 2.0.0-rc.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c48768b270ab6458e2fba295bd3593f76d22058945afb5bdc6a1b1436511402b"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
+"checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
+"checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
 "checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
+"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
+"checksum libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "8a014d9226c2cc402676fbe9ea2e15dd5222cd1dd57f576b5b283178c944a264"
+"checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
+"checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
+"checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
+"checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
+"checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
+"checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
+"checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
+"checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
 "checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"
 "checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
 "checksum subtle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32dbfc4beea0a08bfe33114d0f5e5092f35f6fa387a955b4a2c68888cdd7b0f2"
+"checksum untrusted 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6b65243989ef6aacd9c0d6bd2b822765c3361d8ed352185a6f3a41f3a718c673"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,19 @@ arrayref = "0.3"
 byteorder = { version = "1.1", default-features = false, features = ["i128"] }
 clear_on_drop = { version = "0.2", features = ["nightly"] }
 subtle = { version = "0.2", default-features = false }
+ring = { version = "0.11", optional = true }
 
 [dev-dependencies]
 data-encoding = "2.0.0-rc.1"
 serde_json = "1"
+
+[features]
+bench = ["ring"]
+
+[profile.bench]
+opt-level = 3
+debug = false
+rpath = false
+lto = false
+debug-assertions = false
+codegen-units = 1

--- a/rust/src/bench.rs
+++ b/rust/src/bench.rs
@@ -1,0 +1,112 @@
+extern crate ring;
+
+use self::ring::aead;
+use Aes128Siv;
+use test::Bencher;
+
+// WARNING: Do not ever actually use a key of all zeroes
+const KEY_128_BIT: [u8; 16] = [0u8; 16];
+const KEY_256_BIT: [u8; 32] = [0u8; 32];
+
+const NONCE: [u8; 12] = [0u8; 12];
+
+//
+// AES-SIV benchmarks
+//
+
+#[bench]
+fn bench_aes_siv_128_encrypt_128_bytes(b: &mut Bencher) {
+    let mut siv = Aes128Siv::new(&KEY_256_BIT);
+
+    // 128 bytes input + 16 bytes tag
+    let mut buffer = [0u8; 144];
+    b.bytes = 128;
+
+    b.iter(|| { siv.seal_in_place(&[NONCE], &mut buffer); });
+}
+
+#[bench]
+fn bench_aes_siv_128_encrypt_1024_bytes(b: &mut Bencher) {
+    let mut siv = Aes128Siv::new(&KEY_256_BIT);
+
+    // 1024 bytes input + 16 bytes tag
+    let mut buffer = [0u8; 1040];
+    b.bytes = 1024;
+
+    b.iter(|| { siv.seal_in_place(&[NONCE], &mut buffer); });
+}
+
+#[bench]
+fn bench_aes_siv_128_encrypt_16384_bytes(b: &mut Bencher) {
+    let mut siv = Aes128Siv::new(&KEY_256_BIT);
+
+    // 16384 bytes input + 16 bytes tag
+    let mut buffer = [0u8; 16400];
+    b.bytes = 16384;
+
+    b.iter(|| { siv.seal_in_place(&[NONCE], &mut buffer); });
+}
+
+//
+// AES-GCM benchmarks for comparison (using *ring*)
+//
+
+#[bench]
+fn bench_aes_gcm_128_encrypt_128_bytes(b: &mut Bencher) {
+    let sealing_key = aead::SealingKey::new(&aead::AES_128_GCM, &KEY_128_BIT[..])
+        .expect("valid key");
+
+    // 128 bytes input + 16 bytes tag
+    let mut buffer = [0u8; 144];
+    b.bytes = 128;
+
+    b.iter(|| {
+        aead::seal_in_place(
+            &sealing_key,
+            &NONCE,
+            &b""[..],
+            &mut buffer,
+            sealing_key.algorithm().tag_len(),
+        ).unwrap();
+    });
+}
+
+#[bench]
+fn bench_aes_gcm_128_encrypt_1024_bytes(b: &mut Bencher) {
+    let sealing_key = aead::SealingKey::new(&aead::AES_128_GCM, &KEY_128_BIT[..])
+        .expect("valid key");
+
+    // 1024 bytes input + 16 bytes tag
+    let mut buffer = [0u8; 1040];
+    b.bytes = 1024;
+
+    b.iter(|| {
+        aead::seal_in_place(
+            &sealing_key,
+            &NONCE,
+            &b""[..],
+            &mut buffer,
+            sealing_key.algorithm().tag_len(),
+        ).unwrap();
+    });
+}
+
+#[bench]
+fn bench_aes_gcm_128_encrypt_16384_bytes(b: &mut Bencher) {
+    let sealing_key = aead::SealingKey::new(&aead::AES_128_GCM, &KEY_128_BIT[..])
+        .expect("valid key");
+
+    // 16384 bytes input + 16 bytes tag
+    let mut buffer = [0u8; 16400];
+    b.bytes = 16384;
+
+    b.iter(|| {
+        aead::seal_in_place(
+            &sealing_key,
+            &NONCE,
+            &b""[..],
+            &mut buffer,
+            sealing_key.algorithm().tag_len(),
+        ).unwrap();
+    });
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,12 +15,19 @@
 #![feature(asm)]
 #![feature(attr_literals)]
 #![feature(repr_align)]
+#![cfg_attr(feature = "bench", feature(test))]
+
+#[cfg(all(feature = "bench", test))]
+extern crate test;
 
 #[macro_use]
 extern crate arrayref;
 extern crate byteorder;
 extern crate clear_on_drop;
 extern crate subtle;
+
+#[cfg(feature = "bench")]
+mod bench;
 
 // TODO: reduce visibility by gating it on e.g. #[cfg(debug_assertions)]
 pub mod internals;


### PR DESCRIPTION
Current results:

```
test bench::bench_aes_gcm_128_encrypt_1024_bytes  ... bench:         306 ns/iter (+/- 80) = 3346 MB/s
test bench::bench_aes_gcm_128_encrypt_128_bytes   ... bench:         114 ns/iter (+/- 36) = 1122 MB/s
test bench::bench_aes_gcm_128_encrypt_16384_bytes ... bench:       3,494 ns/iter (+/- 1,187) = 4689 MB/s
test bench::bench_aes_siv_128_encrypt_1024_bytes  ... bench:       3,148 ns/iter (+/- 386) = 325 MB/s
test bench::bench_aes_siv_128_encrypt_128_bytes   ... bench:         485 ns/iter (+/- 67) = 263 MB/s
test bench::bench_aes_siv_128_encrypt_16384_bytes ... bench:      44,556 ns/iter (+/- 9,683) = 367 MB/s
```