### PR TITLE
rust: Use u128s to copy blocks

### DIFF
--- a/rust/src/internals/block.rs
+++ b/rust/src/internals/block.rs
@@ -24,8 +24,8 @@ impl Block {
     /// Panics if the two blocks are the same
     #[inline]
     pub fn copy_from_block(&mut self, other: &Block) {
-        assert_ne!(self.0.as_ptr(), other.0.as_ptr(), "can't copy self");
-        self.0.copy_from_slice(&other.0);
+        let block = NativeEndian::read_u128(&other.0);
+        NativeEndian::write_u128(&mut self.0, block);
     }
 
     /// Performs a doubling operation as defined in the CMAC and SIV papers


### PR DESCRIPTION
This results in a noticible speedup.

Before:

    test bench::bench_aes_siv_128_encrypt_1024_bytes  ... bench:
    4,149 ns/iter (+/- 385) = 246 MB/s
    test bench::bench_aes_siv_128_encrypt_128_bytes   ... bench:
    649 ns/iter (+/- 78) = 197 MB/s
    test bench::bench_aes_siv_128_encrypt_16384_bytes ... bench:
    63,147 ns/iter (+/- 3,339) = 259 MB/s

After:

    test bench::bench_aes_siv_128_encrypt_1024_bytes  ... bench:
    3,279 ns/iter (+/- 216) = 312 MB/s
    test bench::bench_aes_siv_128_encrypt_128_bytes   ... bench:
    551 ns/iter (+/- 82) = 232 MB/s
    test bench::bench_aes_siv_128_encrypt_16384_bytes ... bench:
    51,337 ns/iter (+/- 6,315) = 319 MB/s