### PR TITLE
rust: Use vectorized AES-NI to implement AES-CTR

### DIFF
--- a/rust/src/internals/aes.rs
+++ b/rust/src/internals/aes.rs
@@ -1,6 +1,6 @@
 //! `internals/aes.rs`: The Advanced Encryption Standard block cipher
 
-use super::{Block, BlockCipher};
+use super::{Block, Block8, BlockCipher};
 
 extern crate aesni;
 
@@ -29,6 +29,12 @@ impl BlockCipher for Aes128 {
     fn encrypt(&self, block: &mut Block) {
         self.cipher.encrypt(block.as_mut())
     }
+
+    /// Encrypt a vector of 8 blocks in-place
+    #[inline]
+    fn encrypt8(&self, block8: &mut Block8) {
+        self.cipher.encrypt8(block8.as_mut())
+    }
 }
 
 /// AES with a 256-bit key
@@ -52,5 +58,11 @@ impl BlockCipher for Aes256 {
     #[inline]
     fn encrypt(&self, block: &mut Block) {
         self.cipher.encrypt(block.as_mut())
+    }
+
+    /// Encrypt a vector of 8 blocks in-place
+    #[inline]
+    fn encrypt8(&self, block8: &mut Block8) {
+        self.cipher.encrypt8(block8.as_mut())
     }
 }

--- a/rust/src/internals/block_cipher.rs
+++ b/rust/src/internals/block_cipher.rs
@@ -1,6 +1,6 @@
 //! `internals/block_cipher.rs`: Trait for encrypting with different block ciphers.
 
-use super::Block;
+use super::{Block, Block8};
 
 /// Common interface to a block cipher's raw block function
 ///
@@ -11,4 +11,7 @@ pub trait BlockCipher: Clone {
 
     /// Encrypt a block
     fn encrypt(&self, block: &mut Block);
+
+    /// Encrypt a vector of 8 blocks
+    fn encrypt8(&self, block8: &mut Block8);
 }

--- a/rust/src/internals/ctr.rs
+++ b/rust/src/internals/ctr.rs
@@ -1,13 +1,13 @@
 //! `internals/ctr.rs`: Counter Mode encryption/decryption
 
-use super::{Block, BlockCipher, BLOCK_SIZE};
+use super::{Block, Block8, BlockCipher, BLOCK_SIZE};
 use byteorder::{BigEndian, ByteOrder};
 use clear_on_drop::clear::Clear;
 
 /// Counter Mode encryption/decryption
 pub struct Ctr<C: BlockCipher> {
     cipher: C,
-    buffer: Block,
+    buffer: Block8,
     buffer_pos: usize,
 }
 
@@ -17,58 +17,44 @@ impl<C: BlockCipher> Ctr<C> {
     pub fn new(cipher: C) -> Self {
         Self {
             cipher: cipher,
-            buffer: Block::new(),
-            buffer_pos: BLOCK_SIZE,
+            buffer: Block8::new(),
+            buffer_pos: 8 * BLOCK_SIZE,
         }
     }
 
     /// Reset the internal cipher state back to its initial values
     pub fn reset(&mut self) {
         self.buffer.clear();
-        self.buffer_pos = BLOCK_SIZE;
+        self.buffer_pos = 8 * BLOCK_SIZE;
     }
 
     /// Encrypt/decrypt the given data in-place, updating the internal cipher state
     ///
     /// Accepts a mutable counter value, which is also updated in-place
     pub fn transform(&mut self, counter: &mut Block, data: &mut [u8]) {
+        let mut c = BigEndian::read_u128(counter.as_ref());
+
         for b in data {
-            if self.buffer_pos == BLOCK_SIZE {
-                self.buffer.copy_from_block(counter);
-                self.cipher.encrypt(&mut self.buffer);
+            if self.buffer_pos == 8 * BLOCK_SIZE {
+
+                for i in 0..8 {
+                    BigEndian::write_u128(
+                        array_mut_ref!(self.buffer.as_mut(), i * BLOCK_SIZE, BLOCK_SIZE),
+                        c,
+                    );
+
+                    // AES-CTR uses a wrapping counter
+                    c = c.wrapping_add(1);
+                }
+
+                self.cipher.encrypt8(&mut self.buffer);
                 self.buffer_pos = 0;
-                increment_ctr(counter);
             }
 
             *b ^= self.buffer.as_ref()[self.buffer_pos];
             self.buffer_pos = self.buffer_pos.checked_add(1).expect("overflow");
         }
-    }
-}
 
-/// Increment a CTR-mode counter. Panics on overflow
-// TODO: use verified asm implementation?
-fn increment_ctr(block: &mut Block) {
-    let counter = BigEndian::read_u128(block.as_ref());
-    BigEndian::write_u128(block.as_mut(), counter.wrapping_add(1));
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Block, BLOCK_SIZE};
-    use super::increment_ctr;
-
-    #[test]
-    fn counter_increment() {
-        let mut block = Block::new();
-        increment_ctr(&mut block);
-        assert_eq!(block.as_ref(), *b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01");
-    }
-
-    #[test]
-    fn counter_overflow() {
-        let mut block = Block::from([0xFFu8; BLOCK_SIZE]);
-        increment_ctr(&mut block);
-        assert_eq!(block.as_ref(), &[0u8; BLOCK_SIZE]);
+        BigEndian::write_u128(counter.as_mut(), c);
     }
 }

--- a/rust/src/internals/mod.rs
+++ b/rust/src/internals/mod.rs
@@ -8,7 +8,7 @@ mod ctr;
 mod xor;
 
 pub use self::aes::{Aes128, Aes256};
-pub use self::block::Block;
+pub use self::block::{Block, Block8};
 pub use self::block::SIZE as BLOCK_SIZE;
 pub use self::block_cipher::BlockCipher;
 pub use self::cmac::Cmac;


### PR DESCRIPTION
Adds a `Block8` type for performing vectorized AES operations. Uses `Block8` to implement the internals of AES-CTR.

Provides an approximately 1.4X speedup (Unfortunately AES-CMAC can't be vectorized and becomes the bottleneck).

Before:

```
test bench::bench_aes_siv_128_encrypt_16384_bytes ... bench:
51,337 ns/iter (+/- 6,315) = 319 MB/s
```

After:

```
test bench::bench_aes_siv_128_encrypt_16384_bytes ... bench:
39,036 ns/iter (+/- 5,027) = 419 MB/s
```