### PR TITLE
rust: Faster AES-CTR implementation

### DIFF
--- a/rust/src/bench.rs
+++ b/rust/src/bench.rs
@@ -2,6 +2,7 @@ extern crate ring;
 
 use self::ring::aead;
 use Aes128Siv;
+use internals::{Aes128, Block, Ctr};
 use test::Bencher;
 
 // WARNING: Do not ever actually use a key of all zeroes
@@ -9,6 +10,55 @@ const KEY_128_BIT: [u8; 16] = [0u8; 16];
 const KEY_256_BIT: [u8; 32] = [0u8; 32];
 
 const NONCE: [u8; 12] = [0u8; 12];
+
+//
+// AES-CTR benchmarks
+//
+
+#[bench]
+fn bench_aes_ctr_128_encrypt_128_bytes(b: &mut Bencher) {
+    let mut ctr = Ctr::new(Aes128::new(&KEY_128_BIT));
+    let mut iv = Block::new();
+
+    // 128 bytes input + 16 bytes tag
+    let mut buffer = [0u8; 144];
+    b.bytes = 128;
+
+    b.iter(|| {
+        ctr.transform(&mut iv, &mut buffer);
+        ctr.reset();
+    });
+}
+
+#[bench]
+fn bench_aes_ctr_128_encrypt_1024_bytes(b: &mut Bencher) {
+    let mut ctr = Ctr::new(Aes128::new(&KEY_128_BIT));
+    let mut iv = Block::new();
+
+    // 1024 bytes input + 16 bytes tag
+    let mut buffer = [0u8; 1040];
+    b.bytes = 1024;
+
+    b.iter(|| {
+        ctr.transform(&mut iv, &mut buffer);
+        ctr.reset();
+    });
+}
+
+#[bench]
+fn bench_aes_ctr_128_encrypt_16384_bytes(b: &mut Bencher) {
+    let mut ctr = Ctr::new(Aes128::new(&KEY_128_BIT));
+    let mut iv = Block::new();
+
+    // 16384 bytes input + 16 bytes tag
+    let mut buffer = [0u8; 16400];
+    b.bytes = 16384;
+
+    b.iter(|| {
+        ctr.transform(&mut iv, &mut buffer);
+        ctr.reset();
+    });
+}
 
 //
 // AES-SIV benchmarks

--- a/rust/src/internals/ctr.rs
+++ b/rust/src/internals/ctr.rs
@@ -1,6 +1,6 @@
 //! `internals/ctr.rs`: Counter Mode encryption/decryption
 
-use super::{Block, Block8, BlockCipher, BLOCK_SIZE};
+use super::{BLOCK_SIZE, Block, Block8, BlockCipher, xor};
 use byteorder::{BigEndian, ByteOrder};
 use clear_on_drop::clear::Clear;
 
@@ -31,13 +31,46 @@ impl<C: BlockCipher> Ctr<C> {
     /// Encrypt/decrypt the given data in-place, updating the internal cipher state
     ///
     /// Accepts a mutable counter value, which is also updated in-place
-    pub fn transform(&mut self, counter: &mut Block, data: &mut [u8]) {
+    pub fn transform(&mut self, counter: &mut Block, msg: &mut [u8]) {
         let mut ctr = BigEndian::read_u128(counter.as_ref());
 
-        for b in data {
+        let mut msg_pos: usize = 0;
+        let mut msg_len: usize = msg.len();
+        let remaining: usize = 8 * BLOCK_SIZE - self.buffer_pos;
+
+        if msg_len > remaining {
+            xor::in_place(
+                &mut msg[..remaining],
+                &self.buffer.as_ref()[self.buffer_pos..],
+            );
+
+            msg_pos = msg_pos.checked_add(remaining).expect("overflow");
+            msg_len = msg_len.checked_sub(remaining).expect("underflow");
+
             self.fill_buffer(&mut ctr);
-            *b ^= self.buffer.as_ref()[self.buffer_pos];
-            self.buffer_pos = self.buffer_pos.checked_add(1).expect("overflow");
+        }
+
+        while msg_len > 8 * BLOCK_SIZE {
+            xor::in_place(
+                array_mut_ref!(msg, msg_pos, 8 * BLOCK_SIZE),
+                self.buffer.as_ref(),
+            );
+
+            msg_pos = msg_pos.checked_add(8 * BLOCK_SIZE).expect("overflow");
+            msg_len = msg_len.checked_sub(8 * BLOCK_SIZE).expect("underflow");
+
+            self.fill_buffer(&mut ctr);
+        }
+
+        if msg_len > 0 {
+            let buf_end = self.buffer_pos.checked_add(msg_len).expect("overflow");
+
+            xor::in_place(
+                &mut msg[msg_pos..],
+                &self.buffer.as_ref()[self.buffer_pos..buf_end],
+            );
+
+            self.buffer_pos = self.buffer_pos.checked_add(msg_len).expect("overflow");
         }
 
         BigEndian::write_u128(counter.as_mut(), ctr);
@@ -46,10 +79,6 @@ impl<C: BlockCipher> Ctr<C> {
     /// Fill the internal buffer of AES-CTR values
     #[inline]
     fn fill_buffer(&mut self, counter: &mut u128) {
-        if self.buffer_pos != 8 * BLOCK_SIZE {
-            return;
-        }
-
         for chunk in self.buffer.as_mut().chunks_mut(BLOCK_SIZE) {
             BigEndian::write_u128(chunk, *counter);
 


### PR DESCRIPTION
This implementation goes approximately 4GB/sec on my i7, or about 0.8 cpb.

Benchmark included