### PR TITLE
vectors: AES-PMAC-SIV test vectors

### DIFF
--- a/rust/tests/lib.rs
+++ b/rust/tests/lib.rs
@@ -2,13 +2,13 @@
 extern crate arrayref;
 extern crate miscreant;
 
-use miscreant::{Aes128Siv, Aes256Siv};
+use miscreant::{Aes128Siv, Aes256Siv, Aes128PmacSiv, Aes256PmacSiv};
 use miscreant::internals::{Aes128, Aes256, Block, BlockCipher, Cmac, Ctr, Mac, Pmac};
 use miscreant::internals::BLOCK_SIZE;
 
 mod test_vectors;
 use test_vectors::{AesExample, AesCmacExample, AesCtrExample, AesPmacExample, AesSivExample,
-                   DblExample};
+                   AesPmacSivExample, DblExample};
 
 #[test]
 fn aes_examples() {
@@ -154,6 +154,54 @@ fn aes_siv_examples_open() {
             }
             64 => {
                 let mut siv = Aes256Siv::new(array_ref!(example.key, 0, 64));
+                siv.open_in_place(&example.ad, &mut buffer)
+            }
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        }.expect("successful decrypt");
+
+        assert_eq!(plaintext, &example.plaintext[..]);
+    }
+}
+
+#[test]
+fn aes_pmac_siv_examples_seal() {
+    let examples = AesPmacSivExample::load_all();
+
+    for example in examples {
+        let len = example.plaintext.len();
+        let mut buffer = vec![0; len + BLOCK_SIZE];
+        buffer[BLOCK_SIZE..].copy_from_slice(&example.plaintext);
+
+        match example.key.len() {
+            32 => {
+                let mut siv = Aes128PmacSiv::new(array_ref!(example.key, 0, 32));
+                siv.seal_in_place(&example.ad, &mut buffer);
+            }
+            64 => {
+                let mut siv = Aes256PmacSiv::new(array_ref!(example.key, 0, 64));
+                siv.seal_in_place(&example.ad, &mut buffer);
+            }
+            _ => panic!("unexpected key size: {}", example.key.len()),
+        };
+
+        assert_eq!(buffer, example.ciphertext);
+    }
+}
+
+#[test]
+fn aes_pmac_siv_examples_open() {
+    let examples = AesPmacSivExample::load_all();
+
+    for example in examples {
+        let mut buffer = example.ciphertext.clone();
+
+        let plaintext = match example.key.len() {
+            32 => {
+                let mut siv = Aes128PmacSiv::new(array_ref!(example.key, 0, 32));
+                siv.open_in_place(&example.ad, &mut buffer)
+            }
+            64 => {
+                let mut siv = Aes256PmacSiv::new(array_ref!(example.key, 0, 64));
                 siv.open_in_place(&example.ad, &mut buffer)
             }
             _ => panic!("unexpected key size: {}", example.key.len()),

--- a/rust/tests/test_vectors.rs
+++ b/rust/tests/test_vectors.rs
@@ -292,6 +292,75 @@ impl AesSivExample {
     }
 }
 
+/// AES-SIV test vectors
+// TODO: switch to the tjson crate (based on serde)
+#[derive(Debug)]
+pub struct AesPmacSivExample {
+    pub key: Vec<u8>,
+    pub ad: Vec<Vec<u8>>,
+    pub plaintext: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+}
+
+impl AesPmacSivExample {
+    /// Load examples from aes_pmac_siv.tjson
+    pub fn load_all() -> Vec<Self> {
+        Self::load_from_file(Path::new("../vectors/aes_pmac_siv.tjson"))
+    }
+
+    /// Load examples from a file at the given path
+    pub fn load_from_file(path: &Path) -> Vec<Self> {
+        let mut file = File::open(&path).expect("valid aes_pmac_siv.tjson");
+        let mut tjson_string = String::new();
+        file.read_to_string(&mut tjson_string).expect(
+            "aes_pmac_siv.tjson read successfully",
+        );
+
+        let tjson: serde_json::Value =
+            serde_json::from_str(&tjson_string).expect("aes_pmac_siv.tjson parses successfully");
+        let examples = &tjson["examples:A<O>"].as_array().expect(
+            "aes_pmac_siv.tjson examples array",
+        );
+
+        examples
+            .into_iter()
+            .map(|ex| {
+                Self {
+                    key: HEXLOWER
+                        .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                        .expect("hex encoded"),
+                    ad: ex["ad:A<d16>"]
+                        .as_array()
+                        .expect("encoded example")
+                        .iter()
+                        .map(|ex| {
+                            HEXLOWER
+                                .decode(ex.as_str().expect("encoded example").as_bytes())
+                                .expect("hex encoded")
+                        })
+                        .collect(),
+                    plaintext: HEXLOWER
+                        .decode(
+                            ex["plaintext:d16"]
+                                .as_str()
+                                .expect("encoded example")
+                                .as_bytes(),
+                        )
+                        .expect("hex encoded"),
+                    ciphertext: HEXLOWER
+                        .decode(
+                            ex["ciphertext:d16"]
+                                .as_str()
+                                .expect("encoded example")
+                                .as_bytes(),
+                        )
+                        .expect("hex encoded"),
+                }
+            })
+            .collect()
+    }
+}
+
 /// dbl() test vectors
 // TODO: switch to the tjson crate (based on serde)
 #[derive(Debug)]

--- a/vectors/aes_pmac_siv.tjson
+++ b/vectors/aes_pmac_siv.tjson
@@ -1,0 +1,51 @@
+{
+  "examples:A<O>":[
+    {
+      "name:s":"Deterministic Authenticated Encryption Example",
+      "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+      "ad:A<d16>":[
+        "101112131415161718191a1b1c1d1e1f2021222324252627"
+      ],
+      "plaintext:d16":"112233445566778899aabbccddee",
+      "ciphertext:d16":"8c4b814216140fc9b34a41716aa61633ea66abe16b2f6e4bceeda6e9077f"
+    },
+    {
+      "name:s":"Nonce-Based Authenticated Encryption Example",
+      "key:d16":"7f7e7d7c7b7a79787776757473727170404142434445464748494a4b4c4d4e4f",
+      "ad:A<d16>":[
+        "00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+        "102030405060708090a0",
+        "09f911029d74e35bd84156c5635688c0"
+      ],
+      "plaintext:d16":"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553",
+      "ciphertext:d16":"acb9cbc95dbed8e766d25ad59deb65bcda7aff9214153273f88e89ebe580c77defc15d28448f420e0a17d42722e6d42776849aa3bec375c5a05e54f519e9fd"
+    },
+    {
+      "name:s":"Empty Authenticated Data And Plaintext Example",
+      "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+      "ad:A<d16>":[],
+      "plaintext:d16":"",
+      "ciphertext:d16":"19f25e5ea8a96ef27067d4626fdd3677"
+    },
+    {
+      "name:s":"256-bit key with one associated data field",
+      "key:d16":"fffefdfcfbfaf9f8f7f6f5f4f3f2f1f06f6e6d6c6b6a69686766656463626160f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f",
+      "ad:A<d16>":[
+        "101112131415161718191a1b1c1d1e1f2021222324252627"
+      ],
+      "plaintext:d16":"112233445566778899aabbccddee",
+      "ciphertext:d16":"77097bb3e160988e8b262c1942f983885f826d0d7e047e975e2fc4ea6776"
+    },
+    {
+      "name:s":"256-bit key with three associated data fields",
+      "key:d16":"7f7e7d7c7b7a797877767574737271706f6e6d6c6b6a69686766656463626160404142434445464748494a4b4c4d4e4f505152535455565758595a5b5b5d5e5f",
+      "ad:A<d16>":[
+        "00112233445566778899aabbccddeeffdeaddadadeaddadaffeeddccbbaa99887766554433221100",
+        "102030405060708090a0",
+        "09f911029d74e35bd84156c5635688c0"
+      ],
+      "plaintext:d16":"7468697320697320736f6d6520706c61696e7465787420746f20656e6372797074207573696e67205349562d414553",
+      "ciphertext:d16":"cd07d56dca0fe1569b8ecb3cf2346604290726e12529fc5948546b6be39fed9cd8652256c594c8f56208c7496789de8dfb4f161627c91482f9ecf809652a9e"
+    }
+  ]
+}


### PR DESCRIPTION
As **AES-PMAC-SIV** is effectively a novel construction, it has no existing test vectors to draw from.

This set of test vectors was created by using the same inputs as the **AES-SIV** test vectors, and running them against the Rust **AES-PMAC-SIV** implementation.

This implementation should be correct because:

1) **AES-PMAC** has been tested against Rogaway's test vectors
2) **AES-SIV** has been tested against several vectors
3) **AES-SIV** is implemented as a generic construction, letting us swap within a known-good **AES-SIV** implementation a known-good PMAC implementation.

Based on this, we use the Rust implementation as a reference, and generate test vectors from it in order to test correctness of the other language implementations.