### PR TITLE
go: PMAC implementation

### DIFF
--- a/go/block/block.go
+++ b/go/block/block.go
@@ -1,0 +1,45 @@
+// Common block cipher functionality shared across this library
+
+package block
+
+import (
+	"crypto/cipher"
+	"crypto/subtle"
+)
+
+const (
+	// Size of an AES block in bytes
+	Size = 16
+
+	// R is the minimal irreducible polynomial for a 128-bit block size
+	R = 0x87
+)
+
+// Block is a 128-byte array used by certain block ciphers (i.e. AES)
+type Block [Size]byte
+
+// Clear zeroes out the contents of the block
+func (b *Block) Clear() {
+	// TODO: use a more secure zeroing method that won't be optimized away
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// Dbl performs a doubling of a block over GF(2^128)
+func (b *Block) Dbl() {
+	var z byte
+
+	for i := Size - 1; i >= 0; i-- {
+		zz := b[i] >> 7
+		b[i] = b[i]<<1 | z
+		z = zz
+	}
+
+	b[Size-1] ^= byte(subtle.ConstantTimeSelect(int(z), R, 0))
+}
+
+// Encrypt a block with the given block cipher
+func (b *Block) Encrypt(c cipher.Block) {
+	c.Encrypt(b[:], b[:])
+}

--- a/go/block/block_test.go
+++ b/go/block/block_test.go
@@ -1,0 +1,72 @@
+package block
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+)
+
+type dblExample struct {
+	input  []byte
+	output []byte
+}
+
+// Load dbl test vectors from dbl.tjson
+// TODO: switch to a native Go TJSON parser when available
+func loadDblExamples() []dblExample {
+	var examplesJSON map[string]interface{}
+
+	exampleData, err := ioutil.ReadFile("../../vectors/dbl.tjson")
+	if err != nil {
+		panic(err)
+	}
+
+	if err = json.Unmarshal(exampleData, &examplesJSON); err != nil {
+		panic(err)
+	}
+
+	examplesArray := examplesJSON["examples:A<O>"].([]interface{})
+
+	if examplesArray == nil {
+		panic("no toplevel 'examples:A<O>' key in dbl.tjson")
+	}
+
+	result := make([]dblExample, len(examplesArray))
+
+	for i, exampleJSON := range examplesArray {
+		example := exampleJSON.(map[string]interface{})
+
+		inputHex := example["input:d16"].(string)
+		input := make([]byte, hex.DecodedLen(len(inputHex)))
+
+		if _, err := hex.Decode(input, []byte(inputHex)); err != nil {
+			panic(err)
+		}
+
+		outputHex := example["output:d16"].(string)
+		output := make([]byte, hex.DecodedLen(len(outputHex)))
+
+		if _, err := hex.Decode(output, []byte(outputHex)); err != nil {
+			panic(err)
+		}
+
+		result[i] = dblExample{input, output}
+	}
+
+	return result
+}
+
+func TestDbl(t *testing.T) {
+	for i, tt := range loadDblExamples() {
+		var b Block
+		copy(b[:], tt.input)
+		b.Dbl()
+
+		if !bytes.Equal(b[:], tt.output) {
+			t.Errorf("test %d: dbl mismatch\n\twant %x\n\thave %x", i, tt.output, b)
+			continue
+		}
+	}
+}

--- a/go/pmac/pmac.go
+++ b/go/pmac/pmac.go
@@ -1,0 +1,206 @@
+// PMAC message authentication code, defined in
+// http://web.cs.ucdavis.edu/~rogaway/ocb/pmac.pdf
+
+package pmac
+
+import (
+	"crypto/cipher"
+	"crypto/subtle"
+	"hash"
+
+	"github.com/miscreant/miscreant/go/block"
+)
+
+// Number of L blocks to precompute (i.e. µ in the PMAC paper)
+// TODO: dynamically compute these as needed
+const precomputedBlocks = 31
+
+type pmac struct {
+	// c is the block cipher we're using (i.e. AES-128 or AES-256)
+	c cipher.Block
+
+	// l is defined as follows (quoted from the PMAC paper):
+	//
+	// Equation 1:
+	//
+	//     a · x =
+	//         a<<1 if firstbit(a)=0
+	//         (a<<1) ⊕ 0¹²⁰10000111 if firstbit(a)=1
+	//
+	// Equation 2:
+	//
+	//     a · x⁻¹ =
+	//         a>>1 if lastbit(a)=0
+	//         (a>>1) ⊕ 10¹²⁰1000011 if lastbit(a)=1
+	//
+	// Let L(0) ← L. For i ∈ [1..µ], compute L(i) ← L(i − 1) · x by
+	// Equation (1) using a shift and a conditional xor.
+	//
+	// Compute L(−1) ← L · x⁻¹ by Equation (2), using a shift and a
+	// conditional xor.
+	//
+	// Save the values L(−1), L(0), L(1), L(2), ..., L(µ) in a table.
+	// (Alternatively, [ed: as we have done in this codebase] defer computing
+	// some or  all of these L(i) values until the value is actually needed.)
+	l [precomputedBlocks]block.Block
+
+	// lInv contains the multiplicative inverse (i.e. right shift) of the first
+	// l-value, computed as described above, and is XORed into the tag in the
+	// event the message length is a multiple of the block size
+	lInv block.Block
+
+	// digest contains the PMAC tag-in-progress
+	digest block.Block
+
+	// offset is a block counter-specific tweak to the MAC value
+	offset block.Block
+
+	// buffer is input plaintext, which we process a block-at-a-time
+	buffer block.Block
+
+	// bufferPos marks the end of plaintext in the buffer
+	bufferPos uint
+
+	// counter is the number of blocks we have MAC'd so far
+	counter uint
+
+	// finished is set true when we are done processing a message, and forbids
+	// any subsequent writes until we reset the internal state
+	finished bool
+}
+
+// New creates a new PMAC instance using the given cipher
+func New(c cipher.Block) hash.Hash {
+	if c.BlockSize() != block.Size {
+		panic("pmac: invalid cipher block size")
+	}
+
+	d := new(pmac)
+	d.c = c
+
+	var tmp block.Block
+	tmp.Encrypt(c)
+
+	for i := range d.l {
+		copy(d.l[i][:], tmp[:])
+		tmp.Dbl()
+	}
+
+	copy(tmp[:], d.l[0][:])
+	lastBit := int(tmp[block.Size-1] & 0x01)
+
+	for i := block.Size - 1; i > 0; i-- {
+		carry := byte(subtle.ConstantTimeSelect(int(tmp[i-1]&1), 0x80, 0))
+		tmp[i] = (tmp[i] >> 1) | carry
+	}
+
+	tmp[0] >>= 1
+	tmp[0] ^= byte(subtle.ConstantTimeSelect(lastBit, 0x80, 0))
+	tmp[block.Size-1] ^= byte(subtle.ConstantTimeSelect(lastBit, block.R>>1, 0))
+	copy(d.lInv[:], tmp[:])
+
+	return d
+}
+
+// Reset clears the digest state, starting a new digest.
+func (d *pmac) Reset() {
+	d.digest.Clear()
+	d.offset.Clear()
+	d.buffer.Clear()
+	d.bufferPos = 0
+	d.counter = 0
+	d.finished = false
+}
+
+// Write adds the given data to the digest state.
+func (d *pmac) Write(msg []byte) (int, error) {
+	if d.finished {
+		panic("pmac: already finished")
+	}
+
+	var msgPos, msgLen, remaining uint
+	msgLen = uint(len(msg))
+	remaining = block.Size - d.bufferPos
+
+	// Finish filling the internal buffer with the message
+	if msgLen > remaining {
+		copy(d.buffer[d.bufferPos:], msg[:remaining])
+
+		msgPos += remaining
+		msgLen -= remaining
+
+		d.processBuffer()
+	}
+
+	// So long as we have more than a blocks worth of data, compute
+	// whole-sized blocks at a time.
+	for msgLen > block.Size {
+		copy(d.buffer[:], msg[msgPos:msgPos+block.Size])
+
+		msgPos += block.Size
+		msgLen -= block.Size
+
+		d.processBuffer()
+	}
+
+	if msgLen > 0 {
+		copy(d.buffer[d.bufferPos:d.bufferPos+msgLen], msg[msgPos:])
+		d.bufferPos += msgLen
+	}
+
+	return len(msg), nil
+}
+
+// Sum returns the PMAC digest, one cipher block in length,
+// of the data written with Write.
+func (d *pmac) Sum(in []byte) []byte {
+	if d.finished {
+		panic("pmac: already finished")
+	}
+
+	if d.bufferPos == block.Size {
+		xor(d.digest[:], d.buffer[:])
+		xor(d.digest[:], d.lInv[:])
+	} else {
+		xor(d.digest[:], d.buffer[:d.bufferPos])
+		d.digest[d.bufferPos] ^= 0x80
+	}
+
+	d.digest.Encrypt(d.c)
+	d.finished = true
+
+	return append(in, d.digest[:]...)
+}
+
+func (d *pmac) Size() int { return block.Size }
+
+func (d *pmac) BlockSize() int { return block.Size }
+
+// Update the internal tag state based on the buffer contents
+func (d *pmac) processBuffer() {
+	xor(d.offset[:], d.l[ctz(d.counter+1)][:])
+	xor(d.buffer[:], d.offset[:])
+	d.counter++
+
+	d.buffer.Encrypt(d.c)
+	xor(d.digest[:], d.buffer[:])
+	d.bufferPos = 0
+}
+
+// TODO: use math/bits TrailingZeros() when it becomes available
+// See: https://github.com/golang/go/issues/18616
+func ctz(n uint) uint {
+	var c uint
+	for n&1 == 0 {
+		c++
+		n >>= 1
+	}
+	return c
+}
+
+// XOR the contents of b into a in-place
+func xor(a, b []byte) {
+	for i, v := range b {
+		a[i] ^= v
+	}
+}

--- a/go/pmac/pmac_aes_test.go
+++ b/go/pmac/pmac_aes_test.go
@@ -1,0 +1,166 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pmac
+
+import (
+	"bytes"
+	"crypto/aes"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+)
+
+type pmacAESExample struct {
+	key     []byte
+	message []byte
+	tag     []byte
+}
+
+// Load AES-PMAC test vectors from aes_pmac.tjson
+// TODO: switch to a native Go TJSON parser when available
+func loadPMACAESExamples() []pmacAESExample {
+	var examplesJSON map[string]interface{}
+
+	exampleData, err := ioutil.ReadFile("../../vectors/aes_pmac.tjson")
+	if err != nil {
+		panic(err)
+	}
+
+	if err = json.Unmarshal(exampleData, &examplesJSON); err != nil {
+		panic(err)
+	}
+
+	examplesArray := examplesJSON["examples:A<O>"].([]interface{})
+
+	if examplesArray == nil {
+		panic("no toplevel 'examples:A<O>' key in aes_pmac.tjson")
+	}
+
+	result := make([]pmacAESExample, len(examplesArray))
+
+	for i, exampleJSON := range examplesArray {
+		example := exampleJSON.(map[string]interface{})
+
+		keyHex := example["key:d16"].(string)
+		key := make([]byte, hex.DecodedLen(len(keyHex)))
+
+		if _, err := hex.Decode(key, []byte(keyHex)); err != nil {
+			panic(err)
+		}
+
+		messageHex := example["message:d16"].(string)
+		message := make([]byte, hex.DecodedLen(len(messageHex)))
+
+		if _, err := hex.Decode(message, []byte(messageHex)); err != nil {
+			panic(err)
+		}
+
+		tagHex := example["tag:d16"].(string)
+		tag := make([]byte, hex.DecodedLen(len(tagHex)))
+
+		if _, err := hex.Decode(tag, []byte(tagHex)); err != nil {
+			panic(err)
+		}
+
+		result[i] = pmacAESExample{key, message, tag}
+	}
+
+	return result
+}
+
+func TestPMACAES(t *testing.T) {
+	for i, tt := range loadPMACAESExamples() {
+		c, err := aes.NewCipher(tt.key)
+		if err != nil {
+			t.Errorf("test %d: NewCipher: %s", i, err)
+			continue
+		}
+		d := New(c)
+		n, err := d.Write(tt.message)
+		if err != nil || n != len(tt.message) {
+			t.Errorf("test %d: Write %d: %d, %s", i, len(tt.message), n, err)
+			continue
+		}
+		sum := d.Sum(nil)
+		if !bytes.Equal(sum, tt.tag) {
+			t.Errorf("test %d: tag mismatch\n\twant %x\n\thave %x", i, tt.tag, sum)
+			continue
+		}
+	}
+}
+
+func TestWrite(t *testing.T) {
+	pmacAESTests := loadPMACAESExamples()
+	tt := pmacAESTests[len(pmacAESTests)-1]
+	c, err := aes.NewCipher(tt.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := New(c)
+
+	// Test writing byte-by-byte
+	for _, b := range tt.message {
+		_, err := d.Write([]byte{b})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	sum := d.Sum(nil)
+	if !bytes.Equal(sum, tt.tag) {
+		t.Fatalf("write bytes: tag mismatch\n\twant %x\n\thave %x", tt.tag, sum)
+	}
+
+	// Test writing halves
+	d.Reset()
+
+	_, err = d.Write(tt.message[:len(tt.message)/2])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = d.Write(tt.message[len(tt.message)/2:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sum = d.Sum(nil)
+	if !bytes.Equal(sum, tt.tag) {
+		t.Fatalf("write halves: tag mismatch\n\twant %x\n\thave %x", tt.tag, sum)
+	}
+
+	// Test writing third, then the rest
+	d.Reset()
+	_, err = d.Write(tt.message[:len(tt.message)/3])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = d.Write(tt.message[len(tt.message)/3:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sum = d.Sum(nil)
+	if !bytes.Equal(sum, tt.tag) {
+		t.Fatalf("write third: tag mismatch\n\twant %x\n\thave %x", tt.tag, sum)
+	}
+}
+
+func BenchmarkPMAC_AES128(b *testing.B) {
+	pmacAESTests := loadPMACAESExamples()
+	c, _ := aes.NewCipher(pmacAESTests[0].key)
+	v := make([]byte, 1024)
+	out := make([]byte, 16)
+	b.SetBytes(int64(len(v)))
+	for i := 0; i < b.N; i++ {
+		d := New(c)
+		_, err := d.Write(v)
+		if err != nil {
+			panic(err)
+		}
+		out = d.Sum(out[:0])
+	}
+}


### PR DESCRIPTION
This adds an implementation of PMAC which provides the `hash.Hash` interface.

The implementation has been tested against the common set of AES-PMAC test vectors and passes.

This implementation presently is not vectorized. It looks like Go does not make it simple to use vectorized AES-NI, and vectorizing it would likely require using an ASM implementation instead of `cipher.Block`.