### PR TITLE
go: Refactor CMAC to use the block package

### DIFF
--- a/go/cmac/cmac.go
+++ b/go/cmac/cmac.go
@@ -9,89 +9,76 @@ package cmac
 
 import (
 	"crypto/cipher"
-	"crypto/subtle"
-	"errors"
 	"hash"
-)
 
-const (
-	// minimal irreducible polynomial of degree b
-	r64  = 0x1b
-	r128 = 0x87
+	"github.com/miscreant/miscreant/go/block"
 )
 
 type cmac struct {
-	k1, k2, ci, digest []byte
-	p                  int // position in ci
-	c                  cipher.Block
+	// c is the block cipher we're using (i.e. AES-128 or AES-256)
+	c cipher.Block
+
+	// k1 and k2 are CMAC subkeys (for finishing the tag)
+	k1, k2 block.Block
+
+	// digest contains the PMAC tag-in-progress
+	digest block.Block
+
+	// buffer contains a part of the input message, processed a block-at-a-time
+	buf block.Block
+
+	// pos marks the end of plaintext in the buffer
+	pos uint
 }
 
 // New returns a new instance of a CMAC message authentication code
 // digest using the given cipher.Block.
 func New(c cipher.Block) (hash.Hash, error) {
-	var r int
-	n := c.BlockSize()
-	switch n {
-	case 64 / 8:
-		r = r64
-	case 128 / 8:
-		r = r128
-	default:
-		return nil, errors.New("cmac: invalid cipher block size")
+	if c.BlockSize() != block.Size {
+		panic("pmac: invalid cipher block size")
 	}
 
 	d := new(cmac)
 	d.c = c
-	d.k1 = make([]byte, n)
-	d.k2 = make([]byte, n)
-	d.ci = make([]byte, n)
-	d.digest = make([]byte, n)
 
 	// Subkey generation, p. 7
-	c.Encrypt(d.k1, d.k1)
+	d.k1.Encrypt(c)
+	d.k1.Dbl()
 
-	v1 := shift1(d.k1, d.k1)
-	d.k1[n-1] ^= byte(subtle.ConstantTimeSelect(v1, r, 0))
-
-	v2 := shift1(d.k1, d.k2)
-	d.k2[n-1] ^= byte(subtle.ConstantTimeSelect(v2, r, 0))
+	copy(d.k2[:], d.k1[:])
+	d.k2.Dbl()
 
 	return d, nil
 }
 
 // Reset clears the digest state, starting a new digest.
 func (d *cmac) Reset() {
-	for i := range d.ci {
-		d.ci[i] = 0
-	}
-	for i := range d.digest {
-		d.digest[i] = 0
-	}
-	d.p = 0
+	d.digest.Clear()
+	d.buf.Clear()
+	d.pos = 0
 }
 
 // Write adds the given data to the digest state.
 func (d *cmac) Write(p []byte) (nn int, err error) {
 	nn = len(p)
-	bs := len(d.ci)
-	left := bs - d.p
+	left := block.Size - d.pos
 
-	if len(p) > left {
-		xor(d.ci[d.p:], p[:left])
+	if uint(len(p)) > left {
+		xor(d.buf[d.pos:], p[:left])
 		p = p[left:]
-		d.c.Encrypt(d.ci, d.ci)
-		d.p = 0
+		d.buf.Encrypt(d.c)
+		d.pos = 0
 	}
 
-	for len(p) > bs {
-		xor(d.ci, p[:bs])
-		p = p[bs:]
-		d.c.Encrypt(d.ci, d.ci)
+	for uint(len(p)) > block.Size {
+		xor(d.buf[:], p[:block.Size])
+		p = p[block.Size:]
+		d.buf.Encrypt(d.c)
 	}
 
 	if len(p) > 0 {
-		xor(d.ci[d.p:], p)
-		d.p += len(p)
+		xor(d.buf[d.pos:], p)
+		d.pos += uint(len(p))
 	}
 	return
 }
@@ -103,32 +90,22 @@ func (d *cmac) Sum(in []byte) []byte {
 	// Don't edit ci, in case caller wants
 	// to keep digesting after call to Sum.
 	k := d.k1
-	if d.p < len(d.digest) {
+	if d.pos < uint(len(d.digest)) {
 		k = d.k2
 	}
-	for i := 0; i < len(d.ci); i++ {
-		d.digest[i] = d.ci[i] ^ k[i]
+	for i := 0; i < len(d.buf); i++ {
+		d.digest[i] = d.buf[i] ^ k[i]
 	}
-	if d.p < len(d.digest) {
-		d.digest[d.p] ^= 0x80
+	if d.pos < uint(len(d.digest)) {
+		d.digest[d.pos] ^= 0x80
 	}
-	d.c.Encrypt(d.digest, d.digest)
-	return append(in, d.digest...)
+	d.digest.Encrypt(d.c)
+	return append(in, d.digest[:]...)
 }
 
 func (d *cmac) Size() int { return len(d.digest) }
 
 func (d *cmac) BlockSize() int { return d.c.BlockSize() }
-
-func shift1(src, dst []byte) int {
-	var b byte
-	for i := len(src) - 1; i >= 0; i-- {
-		bb := src[i] >> 7
-		dst[i] = src[i]<<1 | b
-		b = bb
-	}
-	return int(b)
-}
 
 func xor(a, b []byte) {
 	for i, v := range b {


### PR DESCRIPTION
This package provides some abstractions which can be shared across CMAC and PMAC. PMAC is already implemented in terms of these abstractions.

This commit updates CMAC to use the block package, and makes some changes to PMAC for consistency across the two implementations, and hopefully a more Go-like style.