### PR TITLE
README.md: Ratchet up AES-SIV and AES-PMAC-SIV security levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Have questions? Want to suggest a feature or change?
 
 | Name              | [Authenticated Encryption] | [Misuse Resistance] | Performance        | Standardization   |
 |-------------------|----------------------------|---------------------|--------------------|-------------------|
-| AES-SIV           | :green_heart:              | :green_heart:       | :yellow_heart:     | [RFC 5297]        |
-| AES-PMAC-SIV      | :green_heart:              | :green_heart:       | :green_heart:      | None              |
+| AES-SIV           | :green_heart:              | :sparkling_heart:   | :yellow_heart:     | [RFC 5297]        |
+| AES-PMAC-SIV      | :green_heart:              | :sparkling_heart:   | :green_heart:      | None              |
 | AES-GCM-SIV       | :green_heart:              | :green_heart:†      | :sparkling_heart:♣ | Forthcoming‡      |
 | AES-GCM           | :green_heart:              | :broken_heart:      | :sparkling_heart:♣ | [NIST SP 800-38D] |
 | AES-CCM           | :green_heart:              | :broken_heart:      | :yellow_heart:     | [NIST SP 800-38C] |


### PR DESCRIPTION
At Rogaway's suggestion, we have given AES-GCM-SIV a green heart:

https://github.com/miscreant/miscreant/pull/29

We have also given AES-GCM-SIV a sparkling heart for performance.

AES-SIV and AES-PMAC-SIV still have higher security bounds though.

This commit upgrades these ciphers' security level to a sparkling heart.