### PR TITLE
go: Add AES-PMAC-SIV APIs

### DIFF
--- a/go/aead_test.go
+++ b/go/aead_test.go
@@ -7,10 +7,30 @@ import (
 	"testing"
 )
 
-func TestAEADAES(t *testing.T) {
-	v := loadCMACAESExamples()[0]
+func TestAEADAESCMACSIV(t *testing.T) {
+	v := loadAESSIVExamples("aes_siv.tjson")[0]
 	nonce := v.ad[0]
-	c, err := NewAEADAES(v.key, len(nonce))
+	c, err := NewAEAD("AES-SIV", v.key, len(nonce))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct := c.Seal(nil, nonce, v.plaintext, nil)
+	if !bytes.Equal(v.ciphertext, ct) {
+		t.Errorf("Seal: expected: %x\ngot: %x", v.ciphertext, ct)
+	}
+	pt, err := c.Open(nil, nonce, ct, nil)
+	if err != nil {
+		t.Errorf("Open: %s", err)
+	}
+	if !bytes.Equal(v.plaintext, pt) {
+		t.Errorf("Open: expected: %x\ngot: %x", v.plaintext, pt)
+	}
+}
+
+func TestAEADAESPMACSIV(t *testing.T) {
+	v := loadAESSIVExamples("aes_pmac_siv.tjson")[0]
+	nonce := v.ad[0]
+	c, err := NewAEAD("AES-PMAC-SIV", v.key, len(nonce))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/cmac/cmac.go
+++ b/go/cmac/cmac.go
@@ -33,7 +33,7 @@ type cmac struct {
 
 // New returns a new instance of a CMAC message authentication code
 // digest using the given cipher.Block.
-func New(c cipher.Block) (hash.Hash, error) {
+func New(c cipher.Block) hash.Hash {
 	if c.BlockSize() != block.Size {
 		panic("pmac: invalid cipher block size")
 	}
@@ -48,7 +48,7 @@ func New(c cipher.Block) (hash.Hash, error) {
 	copy(d.k2[:], d.k1[:])
 	d.k2.Dbl()
 
-	return d, nil
+	return d
 }
 
 // Reset clears the digest state, starting a new digest.

--- a/go/cmac/cmac_aes_test.go
+++ b/go/cmac/cmac_aes_test.go
@@ -78,11 +78,7 @@ func TestCMACAES(t *testing.T) {
 			t.Errorf("test %d: NewCipher: %s", i, err)
 			continue
 		}
-		d, err := New(c)
-		if err != nil {
-			t.Errorf("test %d: NewCMAC: %s", i, err)
-			continue
-		}
+		d := New(c)
 		n, err := d.Write(tt.message)
 		if err != nil || n != len(tt.message) {
 			t.Errorf("test %d: Write %d: %d, %s", i, len(tt.message), n, err)
@@ -104,10 +100,7 @@ func TestWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d, err := New(c)
-	if err != nil {
-		t.Fatal(err)
-	}
+	d := New(c)
 
 	// Test writing byte-by-byte
 	for _, b := range tt.message {
@@ -188,7 +181,7 @@ func BenchmarkCMAC_AES128(b *testing.B) {
 	out := make([]byte, 16)
 	b.SetBytes(int64(len(v)))
 	for i := 0; i < b.N; i++ {
-		d, _ := New(c)
+		d := New(c)
 		_, err := d.Write(v)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Exposes the full AES-PMAC-SIV construction from the Go library, and tests it
against the shared test vectors.