### PR TITLE
js: AES-PMAC-SIV implementation

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -125,8 +125,12 @@ Miscreant.importKey(keyData, algorithm[, provider = Miscreant.webCryptoProvider(
 * **keyData**: a [Uint8Array] containing the encryption key to use.
   Key must be 32-bytes (for AES-128) or 64-bytes (for AES-256), as
   SIV uses two distinct AES keys to perform its operations.
-* **algorithm**: a string describing the algorithm to use. The only algorithm
-  presently supported is `"AES-SIV"`.
+* **algorithm**: a string describing the algorithm to use. The following
+  algorithms are supported:
+  * `"AES-SIV"`: CMAC-based construction described in [RFC 5297]. Slower but
+  standardized and more common.
+  * `"AES-PMAC-SIV"`: PMAC-based construction. Supports potentially faster
+  implementations, but is non-standard and only available in Miscreant libraries.
 * **provider**: a cryptography provider that implements Miscreant's
   [ICryptoProvider] interface.
 
@@ -154,7 +158,7 @@ decrease security.
 let keyData = new Uint32Array(32);
 window.crypto.getRandomValues(keyData);
 
-let key = await Miscreant.importKey(keyData, "AES-SIV");
+let key = await Miscreant.importKey(keyData, "AES-PMAC-SIV");
 ```
 
 ### seal()
@@ -189,7 +193,7 @@ The **seal()** method returns a [Promise] that, when fulfilled, returns a
 let keyData = new Uint8Array(32);
 window.crypto.getRandomValues(keyData);
 
-let key = await Miscreant.importKey(keyData, "AES-SIV");
+let key = await Miscreant.importKey(keyData, "AES-PMAC-SIV");
 
 // Encrypt plaintext
 
@@ -202,7 +206,8 @@ let ciphertext = await key.seal([nonce], plaintext);
 
 ### open()
 
-The **open()** method decrypts a message which has been encrypted using **AES-SIV**.
+The **open()** method decrypts a message which has been encrypted using
+**AES-SIV** or **AES-PMAC-SIV**.
 
 #### Syntax
 
@@ -232,7 +237,7 @@ will be rejected with an **IntegrityError**.
 let keyData = new Uint8Array(32);
 window.crypto.getRandomValues(keyData);
 
-let key = await Miscreant.importKey(keyData, "AES-SIV");
+let key = await Miscreant.importKey(keyData, "AES-PMAC-SIV");
 
 // Encrypt plaintext
 
@@ -280,7 +285,7 @@ Miscreant.polyfillCryptoProvider()
 You can pass it to `Miscreant.importKey()` like so:
 
 ```
-const key = Miscreant.importKey(keyData, "AES-SIV", Miscreant.polyfillCryptoProvider());
+const key = Miscreant.importKey(keyData, "AES-PMAC-SIV", Miscreant.polyfillCryptoProvider());
 ```
 
 ## Code of Conduct

--- a/js/src/internal/mac/pmac.ts
+++ b/js/src/internal/mac/pmac.ts
@@ -109,7 +109,7 @@ export default class Pmac implements IMacLike {
    * finished is set true when we are done processing a message, and forbids
    * any subsequent writes until we reset the internal state
    */
-  private _finished: boolean;
+  private _finished: boolean = false;
 
   constructor(cipher: IBlockCipher, l: Block[], lInv: Block) {
     this._cipher = cipher;
@@ -126,14 +126,14 @@ export default class Pmac implements IMacLike {
     this._buffer.clear();
     this._bufferPos = 0;
     this._counter = 0;
+    this._offset.clear();
+    this._tag.clear();
     this._finished = false;
     return this;
   }
 
   public clear() {
     this.reset();
-    this._offset.clear();
-    this._tag.clear();
     this._cipher.clear();
   }
 

--- a/js/src/miscreant.ts
+++ b/js/src/miscreant.ts
@@ -15,11 +15,7 @@ export default class Miscreant {
     alg: string,
     provider: ICryptoProvider = Miscreant.webCryptoProvider(),
   ): Promise<ISivLike> {
-    if (alg === "AES-SIV") {
-      return AesSiv.importKey(provider, keyData);
-    } else {
-      throw new Error(`unsupported algorithm: ${alg}`);
-    }
+    return AesSiv.importKey(provider, alg, keyData);
   }
 
   /**

--- a/js/test/aes_pmac_siv.spec.ts
+++ b/js/test/aes_pmac_siv.spec.ts
@@ -1,0 +1,81 @@
+// Copyright (C) 2017 Tony Arcieri, Dmitry Chestnykh
+// MIT License. See LICENSE file for details.
+
+import { suite, test } from "mocha-typescript";
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import { AesPmacSivExample } from "./support/test_vectors";
+
+import WebCrypto = require("node-webcrypto-ossl");
+import PolyfillCryptoProvider from "../src/internal/polyfill/provider";
+import WebCryptoProvider from "../src/internal/webcrypto/provider";
+
+import AesSiv from "../src/internal/aes_siv";
+import IntegrityError from "../src/exceptions/integrity_error";
+
+let expect = chai.expect;
+chai.use(chaiAsPromised);
+
+@suite class AesPmacSivSpec {
+  static vectors: AesPmacSivExample[];
+
+  static async before() {
+    this.vectors = await AesPmacSivExample.loadAll();
+  }
+
+  @test async "should correctly seal and open with polyfill cipher implementations"() {
+    const polyfillProvider = new PolyfillCryptoProvider();
+
+    for (let v of AesPmacSivSpec.vectors) {
+      const siv = await AesSiv.importKey(polyfillProvider, "AES-PMAC-SIV", v.key);
+      const sealed = await siv.seal(v.plaintext, v.ad);
+      expect(sealed).to.eql(v.ciphertext);
+
+      const unsealed = await siv.open(sealed, v.ad, );
+      expect(unsealed).not.to.be.null;
+      expect(unsealed!).to.eql(v.plaintext);
+      expect(() => siv.clear()).not.to.throw();
+    }
+  }
+
+  @test async "should correctly seal and open with WebCrypto cipher implementations"() {
+    const webCryptoProvider = new WebCryptoProvider(new WebCrypto());
+
+    for (let v of AesPmacSivSpec.vectors) {
+      const siv = await AesSiv.importKey(webCryptoProvider, "AES-PMAC-SIV", v.key);
+      const sealed = await siv.seal(v.plaintext, v.ad);
+      expect(sealed).to.eql(v.ciphertext);
+
+      const unsealed = await siv.open(sealed, v.ad, );
+      expect(unsealed).not.to.be.null;
+      expect(unsealed!).to.eql(v.plaintext);
+      expect(() => siv.clear()).not.to.throw();
+    }
+  }
+
+  @test async "should not open with incorrect associated data"() {
+    const polyfillProvider = new PolyfillCryptoProvider();
+
+    for (let v of AesPmacSivSpec.vectors) {
+      const badAd = v.ad;
+      badAd.push(new Uint8Array(1));
+
+      const siv = await AesSiv.importKey(polyfillProvider, "AES-PMAC-SIV", v.key);
+      return expect(siv.open(v.ciphertext, badAd)).to.be.rejectedWith(IntegrityError);
+    }
+  }
+
+  @test async "should not open with incorrect ciphertext"() {
+    const polyfillProvider = new PolyfillCryptoProvider();
+
+    for (let v of AesPmacSivSpec.vectors) {
+      const badOutput = v.ciphertext;
+      badOutput[0] ^= badOutput[0];
+      badOutput[1] ^= badOutput[1];
+      badOutput[3] ^= badOutput[8];
+
+      const siv = await AesSiv.importKey(polyfillProvider, "AES-PMAC-SIV", v.key);
+      return expect(siv.open(badOutput, v.ad)).to.be.rejectedWith(IntegrityError);
+    }
+  }
+}

--- a/js/test/aes_siv.spec.ts
+++ b/js/test/aes_siv.spec.ts
@@ -27,7 +27,7 @@ chai.use(chaiAsPromised);
     const polyfillProvider = new PolyfillCryptoProvider();
 
     for (let v of AesSivSpec.vectors) {
-      const siv = await AesSiv.importKey(polyfillProvider, v.key);
+      const siv = await AesSiv.importKey(polyfillProvider, "AES-SIV", v.key);
       const sealed = await siv.seal(v.plaintext, v.ad);
       expect(sealed).to.eql(v.ciphertext);
 
@@ -42,7 +42,7 @@ chai.use(chaiAsPromised);
     const webCryptoProvider = new WebCryptoProvider(new WebCrypto());
 
     for (let v of AesSivSpec.vectors) {
-      const siv = await AesSiv.importKey(webCryptoProvider, v.key);
+      const siv = await AesSiv.importKey(webCryptoProvider, "AES-SIV", v.key);
       const sealed = await siv.seal(v.plaintext, v.ad);
       expect(sealed).to.eql(v.ciphertext);
 
@@ -63,7 +63,7 @@ chai.use(chaiAsPromised);
     const ad2 = [byteSeq(32), byteSeq(10)];
     const pt2 = byteSeq(40, 100);
 
-    const siv = await AesSiv.importKey(polyfillProvider, key);
+    const siv = await AesSiv.importKey(polyfillProvider, "AES-SIV", key);
 
     const sealed1 = await siv.seal(pt1, ad1);
     const opened1 = await siv.open(sealed1, ad1, );
@@ -87,7 +87,7 @@ chai.use(chaiAsPromised);
       badKey[2] ^= badKey[2];
       badKey[3] ^= badKey[8];
 
-      const siv = await AesSiv.importKey(polyfillProvider, badKey);
+      const siv = await AesSiv.importKey(polyfillProvider, "AES-SIV", badKey);
       expect(siv.open(v.ciphertext, v.ad)).to.be.rejectedWith(IntegrityError);
     }
   }
@@ -99,7 +99,7 @@ chai.use(chaiAsPromised);
       const badAd = v.ad;
       badAd.push(new Uint8Array(1));
 
-      const siv = await AesSiv.importKey(polyfillProvider, v.key);
+      const siv = await AesSiv.importKey(polyfillProvider, "AES-SIV", v.key);
       return expect(siv.open(v.ciphertext, badAd)).to.be.rejectedWith(IntegrityError);
     }
   }
@@ -113,7 +113,7 @@ chai.use(chaiAsPromised);
       badOutput[1] ^= badOutput[1];
       badOutput[3] ^= badOutput[8];
 
-      const siv = await AesSiv.importKey(polyfillProvider, v.key);
+      const siv = await AesSiv.importKey(polyfillProvider, "AES-SIV", v.key);
       return expect(siv.open(badOutput, v.ad)).to.be.rejectedWith(IntegrityError);
     }
   }

--- a/js/test/miscreant.spec.ts
+++ b/js/test/miscreant.spec.ts
@@ -3,14 +3,14 @@
 
 import { suite, test } from "mocha-typescript";
 import { expect } from "chai";
-import { AesSivExample } from "./support/test_vectors";
+import { AesSivExample, AesPmacSivExample } from "./support/test_vectors";
 import WebCryptoProvider from "../src/internal/webcrypto/provider";
 
 import WebCrypto = require("node-webcrypto-ossl");
 
 import Miscreant from "../src/miscreant";
 
-@suite class SivSpec {
+@suite class MiscreantAesSivSpec {
   static vectors: AesSivExample[];
 
   static async before() {
@@ -19,7 +19,7 @@ import Miscreant from "../src/miscreant";
 
   @test async "AES-SIV: should correctly seal and open with PolyfillCrypto"() {
     const polyfillProvider = Miscreant.polyfillCryptoProvider();
-    for (let v of SivSpec.vectors) {
+    for (let v of MiscreantAesSivSpec.vectors) {
       const siv = await Miscreant.importKey(v.key, "AES-SIV", polyfillProvider);
       const sealed = await siv.seal(v.plaintext, v.ad);
       expect(sealed).to.eql(v.ciphertext);
@@ -34,8 +34,45 @@ import Miscreant from "../src/miscreant";
   @test async "AES-SIV: should correctly seal and open with WebCrypto"() {
     const webCryptoProvider = new WebCryptoProvider(new WebCrypto());
 
-    for (let v of SivSpec.vectors) {
+    for (let v of MiscreantAesSivSpec.vectors) {
       const siv = await Miscreant.importKey(v.key, "AES-SIV", webCryptoProvider);
+      const sealed = await siv.seal(v.plaintext, v.ad);
+      expect(sealed).to.eql(v.ciphertext);
+
+      const unsealed = await siv.open(sealed, v.ad);
+      expect(unsealed).not.to.be.null;
+      expect(unsealed!).to.eql(v.plaintext);
+      expect(() => siv.clear()).not.to.throw();
+    }
+  }
+}
+
+@suite class MiscreantAesPmacSivSpec {
+  static vectors: AesPmacSivExample[];
+
+  static async before() {
+    this.vectors = await AesPmacSivExample.loadAll();
+  }
+
+  @test async "AES-PMAC-SIV: should correctly seal and open with PolyfillCrypto"() {
+    const polyfillProvider = Miscreant.polyfillCryptoProvider();
+    for (let v of MiscreantAesPmacSivSpec.vectors) {
+      const siv = await Miscreant.importKey(v.key, "AES-PMAC-SIV", polyfillProvider);
+      const sealed = await siv.seal(v.plaintext, v.ad);
+      expect(sealed).to.eql(v.ciphertext);
+
+      const unsealed = await siv.open(sealed, v.ad);
+      expect(unsealed).not.to.be.null;
+      expect(unsealed!).to.eql(v.plaintext);
+      expect(() => siv.clear()).not.to.throw();
+    }
+  }
+
+  @test async "AES-PMAC-SIV: should correctly seal and open with WebCrypto"() {
+    const webCryptoProvider = new WebCryptoProvider(new WebCrypto());
+
+    for (let v of MiscreantAesPmacSivSpec.vectors) {
+      const siv = await Miscreant.importKey(v.key, "AES-PMAC-SIV", webCryptoProvider);
       const sealed = await siv.seal(v.plaintext, v.ad);
       expect(sealed).to.eql(v.ciphertext);
 

--- a/js/test/support/test_vectors.ts
+++ b/js/test/support/test_vectors.ts
@@ -24,6 +24,29 @@ export class AesSivExample {
   }
 }
 
+/** AES-PMAC-SIV test vectors */
+export class AesPmacSivExample {
+  static readonly DEFAULT_EXAMPLES_PATH = "../vectors/aes_pmac_siv.tjson";
+
+  public readonly name: string;
+  public readonly key: Uint8Array;
+  public readonly ad: Uint8Array[];
+  public readonly plaintext: Uint8Array;
+  public readonly ciphertext: Uint8Array;
+
+  static async loadAll(): Promise<AesPmacSivExample[]> {
+    return AesPmacSivExample.loadFromFile(AesPmacSivExample.DEFAULT_EXAMPLES_PATH);
+  }
+
+  static async loadFromFile(filename: string): Promise<AesPmacSivExample[]> {
+    let tjson = TJSON.parse(await fs.readFile(filename, "utf8"));
+    return tjson["examples"].map((ex: any) => {
+      let obj = Object.create(AesPmacSivExample.prototype);
+      return Object.assign(obj, ex);
+    });
+  }
+}
+
 /** AES (raw block function) test vectors */
 export class AesExample {
   static readonly DEFAULT_EXAMPLES_PATH = "../vectors/aes.tjson";


### PR DESCRIPTION
Implements the full AES-PMAC-SIV construction by adding support for switching
out the MAC used with the existing AES-SIV implementation.

Tests the resulting construction against the shared test vectors.