### PR TITLE
ruby: AES-PMAC implementation

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -39,5 +39,8 @@ Style/ClassAndModuleChildren:
 Style/ConditionalAssignment:
   Enabled: false
 
+Style/NumericPredicate:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/ruby/lib/miscreant/internals.rb
+++ b/ruby/lib/miscreant/internals.rb
@@ -7,6 +7,7 @@ require "miscreant/internals/util"
 require "miscreant/internals/aes/block_cipher"
 require "miscreant/internals/aes/ctr"
 require "miscreant/internals/mac/cmac"
+require "miscreant/internals/mac/pmac"
 
 module Miscreant
   # Internal functionality not intended for direct consumption

--- a/ruby/lib/miscreant/internals/mac/pmac.rb
+++ b/ruby/lib/miscreant/internals/mac/pmac.rb
@@ -1,0 +1,129 @@
+# encoding: binary
+# frozen_string_literal: true
+
+module Miscreant
+  module Internals
+    module MAC # :nodoc:
+      # The Parallel Message Authentication Code
+      class PMAC # :nodoc:
+        # Number of L blocks to precompute (i.e. µ in the PMAC paper)
+        # TODO: dynamically compute these as needed
+        PRECOMPUTED_BLOCKS = 31
+
+        # Create a new PMAC instance
+        #
+        # @param key [String] 16-byte or 32-byte Encoding::BINARY cryptographic key
+        def initialize(key)
+          @cipher = AES::BlockCipher.new(key)
+
+          # L is defined as follows (quoted from the PMAC paper):
+          #
+          # Equation 1:
+          #
+          #     a · x =
+          #         a<<1 if firstbit(a)=0
+          #         (a<<1) ⊕ 0¹²⁰10000111 if firstbit(a)=1
+          #
+          # Equation 2:
+          #
+          #     a · x⁻¹ =
+          #         a>>1 if lastbit(a)=0
+          #         (a>>1) ⊕ 10¹²⁰1000011 if lastbit(a)=1
+          #
+          # Let L(0) ← L. For i ∈ [1..µ], compute L(i) ← L(i − 1) · x by
+          # Equation (1) using a shift and a conditional xor.
+          #
+          # Compute L(−1) ← L · x⁻¹ by Equation (2), using a shift and a
+          # conditional xor.
+          #
+          # Save the values L(−1), L(0), L(1), L(2), ..., L(µ) in a table.
+          # (Alternatively, [ed: as we have done in this codebase] defer computing
+          # some or  all of these L(i) values until the value is actually needed.)
+          @l = []
+          tmp = Block.new
+          tmp.encrypt(@cipher)
+
+          PRECOMPUTED_BLOCKS.times.each do
+            block = Block.new(tmp.data.dup)
+            block.data.freeze
+            block.freeze
+
+            @l << block
+            tmp.dbl
+          end
+
+          @l.freeze
+
+          # Compute L(−1) ← L · x⁻¹:
+          #
+          #     a>>1 if lastbit(a)=0
+          #     (a>>1) ⊕ 10¹²⁰1000011 if lastbit(a)=1
+          #
+          @l_inv = Block.new(@l[0].data.dup)
+          last_bit = @l_inv[Block::SIZE - 1] & 0x01
+
+          (Block::SIZE - 1).downto(1) do |i|
+            carry = Util.ct_select(@l_inv[i - 1] & 1, 0x80, 0)
+            @l_inv[i] = (@l_inv[i] >> 1) | carry
+          end
+
+          @l_inv[0] >>= 1
+          @l_inv[0] ^= Util.ct_select(last_bit, 0x80, 0)
+          @l_inv[Block::SIZE - 1] ^= Util.ct_select(last_bit, Block::R >> 1, 0)
+          @l_inv.freeze
+          @l_inv.data.freeze
+        end
+
+        # Inspect this PMAC instance
+        #
+        # @return [String] description of this instance
+        def inspect
+          to_s
+        end
+
+        # Compute the PMAC of the given input message in a single shot,
+        # outputting the MAC tag.
+        #
+        # Unlike other PMAC implementations, this one does not support
+        # incremental processing/IUF operation. (Though that would enable
+        # slightly more efficient decryption for AES-SIV)
+        #
+        # @param message [String] an Encoding::BINARY string to authenticate
+        #
+        # @return [String] PMAC tag
+        def digest(message)
+          Util.validate_bytestring(message)
+
+          offset = Block.new
+          tmp = Block.new
+          tag = Block.new
+          ctr = 0
+          remaining = message.bytesize
+
+          while remaining > Block::SIZE
+            offset.xor_in_place(@l.fetch(Util.ctz(ctr + 1)))
+
+            tmp.copy(offset)
+            tmp.xor_in_place(message[ctr * Block::SIZE, Block::SIZE])
+            tmp.encrypt(@cipher)
+            tag.xor_in_place(tmp)
+
+            ctr += 1
+            remaining -= Block::SIZE
+          end
+
+          if remaining == Block::SIZE
+            tag.xor_in_place(message[(ctr * Block::SIZE)..-1])
+            tag.xor_in_place(@l_inv)
+          else
+            remaining.times { |i| tag[i] ^= message.getbyte((ctr * Block::SIZE) + i) }
+            tag[remaining] ^= 0x80
+          end
+
+          tag.encrypt(@cipher)
+          tag.data
+        end
+      end
+    end
+  end
+end

--- a/ruby/lib/miscreant/internals/util.rb
+++ b/ruby/lib/miscreant/internals/util.rb
@@ -7,6 +7,26 @@ module Miscreant
     module Util # :nodoc:
       module_function
 
+      # :nodoc: Lookup table for the number of trailing zeroes in a byte
+      CTZ_TABLE = [
+        8, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+        4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0
+      ].freeze
+
       # Perform a constant time-ish comparison of two bytestrings
       def ct_equal(a, b)
         return false unless a.bytesize == b.bytesize
@@ -19,16 +39,23 @@ module Miscreant
         r.zero?
       end
 
+      # Perform a constant time(-ish) branch operation
+      def ct_select(subject, result_if_one, result_if_zero)
+        (~(subject - 1) & result_if_one) | ((subject - 1) & result_if_zero)
+      end
+
+      # Count the number of zeros in a given 8-bit integer
+      #
+      # @param value [Integer] an integer in the 8-bit unsigned range (0-255)
+      def ctz(value)
+        CTZ_TABLE.fetch(value)
+      end
+
       # Pad value with a 0x80 value and zeroes up to the given length
       def pad(message, length)
         padded_length = message.length + length - (message.length % length)
         message += "\x80"
         message.ljust(padded_length, "\0")
-      end
-
-      # Perform a constant time(-ish) branch operation
-      def select(subject, result_if_one, result_if_zero)
-        (~(subject - 1) & result_if_one) | ((subject - 1) & result_if_zero)
       end
 
       # Ensure a string is a valid bytestring (potentially of a given length)

--- a/ruby/spec/miscreant/internals/mac/pmac_spec.rb
+++ b/ruby/spec/miscreant/internals/mac/pmac_spec.rb
@@ -1,0 +1,24 @@
+# encoding: binary
+# frozen_string_literal: true
+
+RSpec.describe Miscreant::Internals::MAC::PMAC do
+  let(:example_key) { ("\x01" * 16).b }
+
+  describe "inspect" do
+    it "does not contain instance variable values" do
+      pmac = described_class.new(example_key)
+      expect(pmac.inspect).to match(/\A#<#{described_class}:0[xX][0-9a-fA-F]+>\z/)
+    end
+  end
+
+  context "AES" do
+    describe "digest" do
+      it "passes all AES-PMAC test vectors" do
+        described_class::Example.load_file.each do |ex|
+          pmac = described_class.new(ex.key)
+          expect(pmac.digest(ex.message)).to eq(ex.tag)
+        end
+      end
+    end
+  end
+end

--- a/ruby/spec/support/test_vectors.rb
+++ b/ruby/spec/support/test_vectors.rb
@@ -67,6 +67,27 @@ class Miscreant::Internals::MAC::CMAC::Example
   end
 end
 
+class Miscreant::Internals::MAC::PMAC::Example
+  attr_reader :name, :key, :message, :tag
+
+  # Default file to load examples from
+  DEFAULT_EXAMPLES = File.expand_path("../../../../vectors/aes_pmac.tjson", __FILE__)
+
+  def self.load_file(filename = DEFAULT_EXAMPLES)
+    examples = TJSON.load_file(filename).fetch("examples")
+    raise ParseError, "expected a toplevel array of examples" unless examples.is_a?(Array)
+
+    examples.map { |example| new(example) }
+  end
+
+  def initialize(attrs)
+    @name = attrs.fetch("name")
+    @key = attrs.fetch("key")
+    @message = attrs.fetch("message")
+    @tag = attrs.fetch("tag")
+  end
+end
+
 class Miscreant::Internals::SIV::Example
   attr_reader :name, :key, :ad, :plaintext, :ciphertext
 


### PR DESCRIPTION
Implements a (non-IUF) PMAC which matches the CMAC implementation.

Perhaps both the CMAC and PMAC implementations should be switched to IUF for consistency with the rest of the implementations.

Does not yet include the full AES-PMAC-SIV construction.