### PR TITLE
ruby: AES-PMAC-SIV implementation

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -17,6 +17,9 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Metrics/BlockLength:
+  Max: 100
+
 Metrics/ClassLength:
   Max: 100
 

--- a/ruby/lib/miscreant/internals/siv.rb
+++ b/ruby/lib/miscreant/internals/siv.rb
@@ -18,11 +18,12 @@ module Miscreant
       # Create a new AES-SIV instance
       #
       # @param key [String] 32-byte or 64-byte Encoding::BINARY cryptographic key
-      def initialize(key)
+      # @param mac [:CMAC, :PMAC] (optional) MAC function to use (default CMAC)
+      def initialize(key, mac_class = :CMAC)
         Util.validate_bytestring(key, length: [32, 64])
         length = key.length / 2
 
-        @mac = MAC::CMAC.new(key[0, length])
+        @mac = MAC.const_get(mac_class).new(key[0, length])
         @ctr = AES::CTR.new(key[length..-1])
       end
 

--- a/ruby/spec/support/test_vectors.rb
+++ b/ruby/spec/support/test_vectors.rb
@@ -91,8 +91,19 @@ end
 class Miscreant::Internals::SIV::Example
   attr_reader :name, :key, :ad, :plaintext, :ciphertext
 
-  # Default file to load examples from
-  DEFAULT_EXAMPLES = File.expand_path("../../../../vectors/aes_siv.tjson", __FILE__)
+  # AES-SIV (RFC 5297) examples
+  CMAC_EXAMPLES = File.expand_path("../../../../vectors/aes_siv.tjson", __FILE__)
+
+  # AES-PMAC-SIV examples
+  PMAC_EXAMPLES = File.expand_path("../../../../vectors/aes_pmac_siv.tjson", __FILE__)
+
+  def self.load_cmac_examples
+    load_file(CMAC_EXAMPLES)
+  end
+
+  def self.load_pmac_examples
+    load_file(PMAC_EXAMPLES)
+  end
 
   def self.load_file(filename = DEFAULT_EXAMPLES)
     examples = TJSON.load_file(filename).fetch("examples")


### PR DESCRIPTION
Adds a parameter to `Miscreant::Internals::SIV` to specify `:CMAC` or `:PMAC` as the
MAC function.

Adds specs for the full AES-PMAC-SIV, which pass.