### PR TITLE
python: PMAC-SIV support

### DIFF
--- a/python/tests/support/test_vectors.py
+++ b/python/tests/support/test_vectors.py
@@ -87,6 +87,12 @@ class SIVExample(namedtuple("SIVExample", ["name", "key", "ad", "plaintext", "ci
 
         return result
 
+class PMACSIVExample(SIVExample):
+    @staticmethod
+    def load():
+        """Load message examples from vectors/aes_pmac_siv.tjson"""
+        return SIVExample.load_from_file("../vectors/aes_pmac_siv.tjson")
+
 class DblExample(namedtuple("DblExample", ["input", "output"])):
     @staticmethod
     def load():

--- a/python/tests/test_aes_siv.py
+++ b/python/tests/test_aes_siv.py
@@ -10,9 +10,10 @@ Tests for the `miscreant.aes.siv` module.
 import unittest
 
 from miscreant.aes.siv import SIV
+from miscreant.mac.pmac import PMAC
 from miscreant.exceptions import IntegrityError
 
-from .support.test_vectors import SIVExample
+from .support.test_vectors import SIVExample, PMACSIVExample
 
 class TestAesSiv(unittest.TestCase):
     # Ensure we can generate random keys with the right default size
@@ -50,3 +51,18 @@ class TestAesSiv(unittest.TestCase):
             siv = SIV(ex.key)
             with self.assertRaises(IntegrityError):
                 siv.open(ex.ciphertext, bad_ad)
+
+class TestAesPmacSiv(unittest.TestCase):
+    # Ensure seal passes all AES-SIV test vectors
+    def test_seal(self):
+        for ex in PMACSIVExample.load():
+            siv = SIV(ex.key, PMAC)
+            ciphertext = siv.seal(ex.plaintext, ex.ad)
+            self.assertEqual(ciphertext, ex.ciphertext)
+
+    # Ensure open passes all AES-SIV test vectors
+    def test_open(self):
+        for ex in PMACSIVExample.load():
+            siv = SIV(ex.key, PMAC)
+            plaintext = siv.open(ex.ciphertext, ex.ad)
+            self.assertEqual(plaintext, ex.plaintext)


### PR DESCRIPTION
Makes the MAC used by AES-SIV a parameter, and adds test cases for doing AES-SIV with PMAC.