### PR TITLE
rust: Update panic conditions for Block::copy_from_block

### DIFF
--- a/rust/src/internals/block.rs
+++ b/rust/src/internals/block.rs
@@ -23,8 +23,6 @@ impl Block {
     }
 
     /// Copy the contents of the other block into this one
-    ///
-    /// Panics if the two blocks are the same
     #[inline]
     pub fn copy_from_block(&mut self, other: &Block) {
         let block = NativeEndian::read_u128(&other.0);


### PR DESCRIPTION
This function used to contain a pointer equality check, but it was removed in 462d4b190d5f5c0f294b27b6114dea8d64566602.  It's impossible for the two references to alias without UB, anyways.