### PR TITLE
rust: Use AES-CTR implementation from the 'aesni' crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1,21 +1,10 @@
-[root]
-name = "miscreant"
-version = "0.2.0"
-dependencies = [
- "aesni 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clear_on_drop 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "data-encoding 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aesni"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.2.0"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#3f7e7cb6b895b9c99238d035bc971dbefe197101"
+dependencies = [
+ "block-cipher-trait 0.5.0 (git+https://github.com/RustCrypto/traits.git)",
+]
 
 [[package]]
 name = "arrayref"
@@ -26,6 +15,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "block-cipher-trait"
+version = "0.5.0"
+source = "git+https://github.com/RustCrypto/traits.git#cd062e07f034a73a42c841ec7cf47804e6e41e79"
+dependencies = [
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "byteorder"
@@ -45,8 +42,8 @@ name = "coco"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -61,7 +58,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "either"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -81,14 +78,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "gcc"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "generic-array"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "itoa"
@@ -97,13 +97,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "miscreant"
+version = "0.2.0"
+dependencies = [
+ "aesni 0.2.0 (git+https://github.com/RustCrypto/block-ciphers.git)",
+ "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clear_on_drop 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "data-encoding 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num-traits"
@@ -115,16 +129,16 @@ name = "num_cpus"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -132,20 +146,19 @@ name = "rayon"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -154,31 +167,31 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.15"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_json"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -187,35 +200,42 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "typenum"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "untrusted"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aesni 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ef0ab1be561c7753c0c416e1b73466c5a07a134c222f4115a4c76ea6526eb56a"
+"checksum aesni 0.2.0 (git+https://github.com/RustCrypto/block-ciphers.git)" = "<none>"
 "checksum arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd1479b7c29641adbd35ff3b5c293922d696a92f25c8c975da3e0acbc87258f"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum block-cipher-trait 0.5.0 (git+https://github.com/RustCrypto/traits.git)" = "<none>"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum clear_on_drop 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "27fc408dd80e7fe9d5b1c8cee6c2add84bea237d8dee70880a76ae7957f6d3a6"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum data-encoding 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d26bb7bacfa6d2e9d049b98978076e7ab6517caddd4d47b8d53e7f33a85846f8"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum either 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbee135e9245416869bf52bd6ccc9b59e2482651510784e089b874272f02a252"
+"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
 "checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
-"checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
-"checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
-"checksum libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "56cce3130fd040c28df6f495c8492e5ec5808fb4c9093c310df02b0c8f030148"
+"checksum lazy_static 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "236eb37a62591d4a41a89b7763d7de3e06ca02d5ab2815446a8bae5d2f8c2d57"
+"checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
-"checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"
+"checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
-"checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
+"checksum rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e64b609139d83da75902f88fd6c01820046840a18471e4dfcd5ac7c0f46bea53"
 "checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
-"checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
-"checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
-"checksum serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d243424e06f9f9c39e3cd36147470fd340db785825e367625f79298a6ac6b7ac"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6eda663e865517ee783b0891a3f6eb3a253e0b0dabb46418969ee9635beadd9e"
+"checksum serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e4586746d1974a030c48919731ecffd0ed28d0c40749d0d18d43b3a7d6c9b20e"
 "checksum subtle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32dbfc4beea0a08bfe33114d0f5e5092f35f6fa387a955b4a2c68888cdd7b0f2"
+"checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ categories  = ["cryptography", "no-std"]
 keywords    = ["cryptography", "encryption", "security", "streaming"]
 
 [dependencies]
-aesni = "0.1"
+aesni = { git = "https://github.com/RustCrypto/block-ciphers.git" }
 arrayref = "0.3"
 byteorder = { version = "1.1", default-features = false, features = ["i128"] }
 clear_on_drop = { version = "0.2", features = ["nightly"] }
@@ -32,3 +32,6 @@ rpath = false
 lto = false
 debug-assertions = false
 codegen-units = 1
+
+[patch.crates-io.block-cipher-trait]
+git = "https://github.com/RustCrypto/traits.git"

--- a/rust/src/bench.rs
+++ b/rust/src/bench.rs
@@ -2,7 +2,7 @@ extern crate ring;
 
 use self::ring::aead;
 use {Aes128Siv, Aes128PmacSiv};
-use internals::{Aes128, Block, Cmac, Ctr, Pmac, Mac};
+use internals::{Aes128Cmac, Aes128Ctr, Aes128Pmac, Block, Ctr, Mac};
 use test::Bencher;
 
 // WARNING: Do not ever actually use a key of all zeroes
@@ -17,7 +17,7 @@ const NONCE: [u8; 12] = [0u8; 12];
 
 #[bench]
 fn bench_aes_cmac_128_mac_128_bytes(b: &mut Bencher) {
-    let mut cmac = Cmac::new(Aes128::new(&KEY_128_BIT));
+    let mut cmac = Aes128Cmac::new(&KEY_128_BIT);
 
     // 128 bytes input + 16 bytes tag
     let buffer = [0u8; 144];
@@ -32,7 +32,7 @@ fn bench_aes_cmac_128_mac_128_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_aes_cmac_128_mac_1024_bytes(b: &mut Bencher) {
-    let mut cmac = Cmac::new(Aes128::new(&KEY_128_BIT));
+    let mut cmac = Aes128Cmac::new(&KEY_128_BIT);
 
     // 1024 bytes input + 16 bytes tag
     let buffer = [0u8; 1040];
@@ -47,7 +47,7 @@ fn bench_aes_cmac_128_mac_1024_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_aes_cmac_128_mac_16384_bytes(b: &mut Bencher) {
-    let mut cmac = Cmac::new(Aes128::new(&KEY_128_BIT));
+    let mut cmac = Aes128Cmac::new(&KEY_128_BIT);
 
     // 16384 bytes input + 16 bytes tag
     let buffer = [0u8; 16400];
@@ -66,47 +66,35 @@ fn bench_aes_cmac_128_mac_16384_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_aes_ctr_128_encrypt_128_bytes(b: &mut Bencher) {
-    let mut ctr = Ctr::new(Aes128::new(&KEY_128_BIT));
-    let mut iv = Block::new();
+    let ctr = Aes128Ctr::new(&KEY_128_BIT);
+    let iv = Block::new();
 
     // 128 bytes input + 16 bytes tag
     let mut buffer = [0u8; 144];
     b.bytes = 128;
-
-    b.iter(|| {
-        ctr.transform(&mut iv, &mut buffer);
-        ctr.reset();
-    });
+    b.iter(|| ctr.xor_in_place(&iv, &mut buffer));
 }
 
 #[bench]
 fn bench_aes_ctr_128_encrypt_1024_bytes(b: &mut Bencher) {
-    let mut ctr = Ctr::new(Aes128::new(&KEY_128_BIT));
-    let mut iv = Block::new();
+    let ctr = Aes128Ctr::new(&KEY_128_BIT);
+    let iv = Block::new();
 
     // 1024 bytes input + 16 bytes tag
     let mut buffer = [0u8; 1040];
     b.bytes = 1024;
-
-    b.iter(|| {
-        ctr.transform(&mut iv, &mut buffer);
-        ctr.reset();
-    });
+    b.iter(|| ctr.xor_in_place(&iv, &mut buffer));
 }
 
 #[bench]
 fn bench_aes_ctr_128_encrypt_16384_bytes(b: &mut Bencher) {
-    let mut ctr = Ctr::new(Aes128::new(&KEY_128_BIT));
-    let mut iv = Block::new();
+    let ctr = Aes128Ctr::new(&KEY_128_BIT);
+    let iv = Block::new();
 
     // 16384 bytes input + 16 bytes tag
     let mut buffer = [0u8; 16400];
     b.bytes = 16384;
-
-    b.iter(|| {
-        ctr.transform(&mut iv, &mut buffer);
-        ctr.reset();
-    });
+    b.iter(|| ctr.xor_in_place(&iv, &mut buffer));
 }
 
 //
@@ -115,7 +103,7 @@ fn bench_aes_ctr_128_encrypt_16384_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_aes_pmac_128_mac_128_bytes(b: &mut Bencher) {
-    let mut pmac = Pmac::new(Aes128::new(&KEY_128_BIT));
+    let mut pmac = Aes128Pmac::new(&KEY_128_BIT);
 
     // 128 bytes input + 16 bytes tag
     let buffer = [0u8; 144];
@@ -130,7 +118,7 @@ fn bench_aes_pmac_128_mac_128_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_aes_pmac_128_mac_1024_bytes(b: &mut Bencher) {
-    let mut pmac = Pmac::new(Aes128::new(&KEY_128_BIT));
+    let mut pmac = Aes128Pmac::new(&KEY_128_BIT);
 
     // 1024 bytes input + 16 bytes tag
     let buffer = [0u8; 1040];
@@ -145,7 +133,7 @@ fn bench_aes_pmac_128_mac_1024_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_aes_pmac_128_mac_16384_bytes(b: &mut Bencher) {
-    let mut pmac = Pmac::new(Aes128::new(&KEY_128_BIT));
+    let mut pmac = Aes128Pmac::new(&KEY_128_BIT);
 
     // 16384 bytes input + 16 bytes tag
     let buffer = [0u8; 16400];

--- a/rust/src/internals/aes.rs
+++ b/rust/src/internals/aes.rs
@@ -17,7 +17,7 @@ impl Aes128 {
     /// Create a new AES-128 cipher instance from the given key
     #[inline]
     pub fn new(key: &[u8; 16]) -> Self {
-        Self { cipher: Aes128Ni::new(key) }
+        Self { cipher: Aes128Ni::init(key) }
     }
 }
 
@@ -47,7 +47,7 @@ impl Aes256 {
     /// Create a new AES-256 cipher instance from the given key
     #[inline]
     pub fn new(key: &[u8; 32]) -> Self {
-        Self { cipher: Aes256Ni::new(key) }
+        Self { cipher: Aes256Ni::init(key) }
     }
 }
 

--- a/rust/src/internals/mac/mod.rs
+++ b/rust/src/internals/mac/mod.rs
@@ -1,12 +1,14 @@
-//! `internals/mac.rs`: Message Authentication Codes (MACs)
+//! `internals/mac/mod.rs`: Message Authentication Codes (MACs)
 
-use super::{Block, BlockCipher};
+mod cmac;
+mod pmac;
+
+pub use self::cmac::{Aes128Cmac, Aes256Cmac};
+pub use self::pmac::{Aes128Pmac, Aes256Pmac};
+use super::Block;
 
 /// Trait for Message Authentication Codes (MACs)
-pub trait Mac<C: BlockCipher> {
-    /// Create a new MAC instance with the given cipher
-    fn new(cipher: C) -> Self;
-
+pub trait Mac {
     /// Reset a MAC instance back to its initial state
     fn reset(&mut self);
 

--- a/rust/src/internals/mod.rs
+++ b/rust/src/internals/mod.rs
@@ -3,17 +3,13 @@
 mod aes;
 mod block;
 pub mod block_cipher;
-mod cmac;
-mod ctr;
-mod mac;
-mod pmac;
+pub mod ctr;
+pub mod mac;
 mod xor;
 
 pub use self::aes::{Aes128, Aes256};
 pub use self::block::{Block, Block8};
 pub use self::block::SIZE as BLOCK_SIZE;
 pub use self::block_cipher::BlockCipher;
-pub use self::cmac::Cmac;
-pub use self::ctr::Ctr;
-pub use self::mac::Mac;
-pub use self::pmac::Pmac;
+pub use self::ctr::{Aes128Ctr, Aes256Ctr, Ctr};
+pub use self::mac::{Aes128Cmac, Aes128Pmac, Aes256Cmac, Aes256Pmac, Mac};

--- a/rust/tests/lib.rs
+++ b/rust/tests/lib.rs
@@ -3,8 +3,9 @@ extern crate arrayref;
 extern crate miscreant;
 
 use miscreant::{Aes128Siv, Aes256Siv, Aes128PmacSiv, Aes256PmacSiv};
-use miscreant::internals::{Aes128, Aes256, Block, BlockCipher, Cmac, Ctr, Mac, Pmac};
-use miscreant::internals::BLOCK_SIZE;
+use miscreant::internals::{Aes128, Aes128Cmac, Aes128Ctr, Aes128Pmac};
+use miscreant::internals::{Aes256, Aes256Cmac, Aes256Ctr, Aes256Pmac};
+use miscreant::internals::{BLOCK_SIZE, Block, BlockCipher, Ctr, Mac};
 
 mod test_vectors;
 use test_vectors::{AesExample, AesCmacExample, AesCtrExample, AesPmacExample, AesSivExample,
@@ -41,16 +42,12 @@ fn aes_cmac_examples() {
     for example in examples {
         let result = match example.key.len() {
             16 => {
-                let aes = Aes128::new(array_ref!(example.key, 0, 16));
-                let mut aes_cmac = Cmac::new(aes);
-
+                let mut aes_cmac = Aes128Cmac::new(array_ref!(example.key, 0, 16));
                 aes_cmac.update(&example.message);
                 aes_cmac.finish()
             }
             32 => {
-                let aes = Aes256::new(array_ref!(example.key, 0, 32));
-                let mut aes_cmac = Cmac::new(aes);
-
+                let mut aes_cmac = Aes256Cmac::new(array_ref!(example.key, 0, 32));
                 aes_cmac.update(&example.message);
                 aes_cmac.finish()
             }
@@ -70,16 +67,14 @@ fn aes_ctr_examples() {
 
         match example.key.len() {
             16 => {
-                let aes = Aes128::new(array_ref!(example.key, 0, 16));
-                let mut aes_ctr = Ctr::new(aes);
-                let mut iv = Block::from(&example.iv[..]);
-                aes_ctr.transform(&mut iv, &mut buffer);
+                let aes_ctr = Aes128Ctr::new(array_ref!(example.key, 0, 16));
+                let iv = Block::from(&example.iv[..]);
+                aes_ctr.xor_in_place(&iv, &mut buffer);
             }
             32 => {
-                let aes = Aes256::new(array_ref!(example.key, 0, 32));
-                let mut aes_ctr = Ctr::new(aes);
-                let mut iv = Block::from(&example.iv[..]);
-                aes_ctr.transform(&mut iv, &mut buffer);
+                let aes_ctr = Aes256Ctr::new(array_ref!(example.key, 0, 32));
+                let iv = Block::from(&example.iv[..]);
+                aes_ctr.xor_in_place(&iv, &mut buffer);
             }
             _ => panic!("unexpected key size: {}", example.key.len()),
         };
@@ -95,16 +90,12 @@ fn aes_pmac_examples() {
     for example in examples {
         let result = match example.key.len() {
             16 => {
-                let aes = Aes128::new(array_ref!(example.key, 0, 16));
-                let mut aes_pmac = Pmac::new(aes);
-
+                let mut aes_pmac = Aes128Pmac::new(array_ref!(example.key, 0, 16));
                 aes_pmac.update(&example.message);
                 aes_pmac.finish()
             }
             32 => {
-                let aes = Aes256::new(array_ref!(example.key, 0, 32));
-                let mut aes_pmac = Pmac::new(aes);
-
+                let mut aes_pmac = Aes256Pmac::new(array_ref!(example.key, 0, 32));
                 aes_pmac.update(&example.message);
                 aes_pmac.finish()
             }


### PR DESCRIPTION
Results in a nice performance boost.

Before:

    aes_ctr_128_encrypt_16384_bytes:       4,397 ns/iter (+/- 673)   = 3726 MB/s
    aes_pmac_siv_128_encrypt_16384_bytes: 13,193 ns/iter (+/- 1,782) = 1241 MB/s

After:

    aes_ctr_128_encrypt_16384_bytes:       2,834 ns/iter (+/- 616)   = 5781 MB/s
    aes_pmac_siv_128_encrypt_16384_bytes: 11,382 ns/iter (+/- 2,029) = 1439 MB/s