### PR TITLE
rust: Deny unsafe_code

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7,11 +7,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,11 +18,6 @@ source = "git+https://github.com/RustCrypto/traits.git?branch=new_versiion#03af6
 dependencies = [
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clear_on_drop"
@@ -142,9 +132,7 @@ name = "miscreant"
 version = "0.2.0"
 dependencies = [
  "aesni 0.2.0 (git+https://github.com/RustCrypto/block-ciphers.git)",
- "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "block-cipher-trait 0.5.0 (git+https://github.com/RustCrypto/traits.git?branch=new_versiion)",
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmac 0.1.0 (git+https://github.com/RustCrypto/MACs.git)",
  "crypto-mac 0.6.0 (git+https://github.com/RustCrypto/traits.git?branch=new_versiion)",
@@ -258,10 +246,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aesni 0.2.0 (git+https://github.com/RustCrypto/block-ciphers.git)" = "<none>"
-"checksum arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd1479b7c29641adbd35ff3b5c293922d696a92f25c8c975da3e0acbc87258f"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum block-cipher-trait 0.5.0 (git+https://github.com/RustCrypto/traits.git?branch=new_versiion)" = "<none>"
-"checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum clear_on_drop 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "27fc408dd80e7fe9d5b1c8cee6c2add84bea237d8dee70880a76ae7957f6d3a6"
 "checksum cmac 0.1.0 (git+https://github.com/RustCrypto/MACs.git)" = "<none>"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,17 +11,15 @@ categories  = ["cryptography", "no-std"]
 keywords    = ["cryptography", "encryption", "security", "streaming"]
 
 [dependencies]
-aesni = { git = "https://github.com/RustCrypto/block-ciphers.git" }
-arrayref = "0.3"
+aesni = "0.2.0"
 crypto-mac = "0.6"
 block-cipher-trait = "0.5"
-byteorder = { version = "1.1", default-features = false, features = ["i128"] }
 clear_on_drop = { version = "0.2", features = ["nightly"] }
-cmac = { git = "https://github.com/RustCrypto/MACs.git" }
+cmac = "0.1"
 dbl = "0.1"
-pmac = { git = "https://github.com/RustCrypto/MACs.git" }
-subtle = { version = "0.3", default-features = false }
+pmac = "0.1"
 ring = { version = "0.11", optional = true }
+subtle = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 data-encoding = "2.0"
@@ -39,5 +37,8 @@ debug-assertions = false
 codegen-units = 1
 
 [patch.crates-io]
+aesni = { git = "https://github.com/RustCrypto/block-ciphers.git" }
 block-cipher-trait = { git = "https://github.com/RustCrypto/traits.git", branch = "new_versiion" }
+cmac = { git = "https://github.com/RustCrypto/MACs.git" }
 crypto-mac = { git = "https://github.com/RustCrypto/traits.git", branch = "new_versiion" }
+pmac = { git = "https://github.com/RustCrypto/MACs.git" }

--- a/rust/src/ctr.rs
+++ b/rust/src/ctr.rs
@@ -2,15 +2,10 @@
 
 use aesni::CtrAes128 as CtrAesNi128;
 use aesni::CtrAes256 as CtrAesNi256;
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::generic_array::typenum::U16;
 use clear_on_drop::clear::Clear;
 
 /// Size of the initial counter value in bytes
 pub const IV_SIZE: usize = 16;
-
-/// Initial counter value (a.k.a. initialization vector or IV)
-pub type Iv = GenericArray<u8, U16>;
 
 /// Common interface to counter mode encryption/decryption
 pub trait Ctr {
@@ -18,7 +13,7 @@ pub trait Ctr {
     fn new(key: &[u8]) -> Self;
 
     /// XOR the CTR keystream into the given buffer
-    fn xor_in_place(&self, iv: &Iv, buf: &mut [u8]);
+    fn xor_in_place(&self, iv: &[u8; IV_SIZE], buf: &mut [u8]);
 }
 
 /// AES-CTR with a 128-bit key
@@ -31,11 +26,15 @@ impl Ctr for Aes128Ctr {
     #[inline]
     fn new(key: &[u8]) -> Self {
         debug_assert_eq!(key.len(), 16, "expected 16-byte key, got {}", key.len());
-        Self { key: *array_ref!(key, 0, 16) }
+
+        let mut k = [0u8; 16];
+        k.copy_from_slice(key);
+
+        Self { key: k }
     }
 
-    fn xor_in_place(&self, iv: &Iv, buf: &mut [u8]) {
-        CtrAesNi128::new(&self.key, array_ref!(iv, 0, 16)).xor(buf);
+    fn xor_in_place(&self, iv: &[u8; IV_SIZE], buf: &mut [u8]) {
+        CtrAesNi128::new(&self.key, iv).xor(buf);
     }
 }
 
@@ -54,12 +53,16 @@ pub struct Aes256Ctr {
 impl Ctr for Aes256Ctr {
     #[inline]
     fn new(key: &[u8]) -> Self {
-        debug_assert_eq!(key.len(), 32, "expected 16-byte key, got {}", key.len());
-        Self { key: *array_ref!(key, 0, 32) }
+        debug_assert_eq!(key.len(), 32, "expected 32-byte key, got {}", key.len());
+
+        let mut k = [0u8; 32];
+        k.copy_from_slice(key);
+
+        Self { key: k }
     }
 
-    fn xor_in_place(&self, iv: &Iv, buf: &mut [u8]) {
-        CtrAesNi256::new(&self.key, array_ref!(iv, 0, 16)).xor(buf);
+    fn xor_in_place(&self, iv: &[u8; IV_SIZE], buf: &mut [u8]) {
+        CtrAesNi256::new(&self.key, iv).xor(buf);
     }
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,24 +5,15 @@
 #![crate_type = "lib"]
 
 #![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
-#![deny(unused_import_braces, unused_qualifications)]
+#![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 
 #![no_std]
 
-// Experimental features
-// TODO: make crate work on stable
-#![feature(i128_type)]
-#![feature(asm)]
-#![feature(attr_literals)]
 #![cfg_attr(feature = "bench", feature(test))]
-
 #[cfg(all(feature = "bench", test))]
 extern crate test;
 
 extern crate aesni;
-#[macro_use]
-extern crate arrayref;
-extern crate byteorder;
 extern crate block_cipher_trait;
 extern crate clear_on_drop;
 extern crate cmac;


### PR DESCRIPTION
Removes the remaining usages of array_ref! which allows us to `#![deny(unsafe_code)]`