### PR TITLE
rust: Factor s2v() into its own module

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "crypto-mac 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pmac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,6 +17,7 @@ block-cipher-trait = "0.5"
 clear_on_drop = { version = "0.2", features = ["nightly"] }
 cmac = "0.1"
 dbl = "0.1"
+generic-array = "0.9"
 pmac = "0.1"
 ring = { version = "0.11", optional = true }
 subtle = { version = "0.3", default-features = false }

--- a/rust/src/aead.rs
+++ b/rust/src/aead.rs
@@ -3,7 +3,7 @@
 //! and authenticity.
 
 use ctr::IV_SIZE;
-use siv::{Aes128Siv, Aes256Siv, Aes128PmacSiv, Aes256PmacSiv, Siv};
+use siv::{self, Siv};
 
 /// An AEAD algorithm
 pub trait Algorithm {
@@ -30,10 +30,11 @@ pub trait Algorithm {
     ) -> Result<&'a [u8], ()>;
 }
 
+/// Generate AEAD newtypes for SIV types
 macro_rules! impl_siv_aead {
-    ($name:ident, $siv:ty, $key_size:expr, $doc:expr) => {
+    ($name:ident, $key_size:expr, $doc:expr) => {
         #[doc=$doc]
-        pub struct $name($siv);
+        pub struct $name(siv::$name);
 
         impl Algorithm for $name {
             const KEY_SIZE: usize = $key_size;
@@ -60,28 +61,24 @@ macro_rules! impl_siv_aead {
 }
 
 impl_siv_aead!(
-    Aes128SivAead,
     Aes128Siv,
     16,
     "AES-CMAC-SIV in AEAD mode with 128-bit key size"
 );
 
 impl_siv_aead!(
-    Aes256SivAead,
     Aes256Siv,
     32,
     "AES-CMAC-SIV in AEAD mode with 256-bit key size"
 );
 
 impl_siv_aead!(
-    Aes128PmacSivAead,
     Aes128PmacSiv,
     16,
     "AES-PMAC-SIV in AEAD mode with 128-bit key size"
 );
 
 impl_siv_aead!(
-    Aes256PmacSivAead,
     Aes256PmacSiv,
     32,
     "AES-PMAC-SIV in AEAD mode with 256-bit key size"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -19,12 +19,14 @@ extern crate clear_on_drop;
 extern crate cmac;
 extern crate crypto_mac;
 extern crate dbl;
+extern crate generic_array;
 extern crate pmac;
 extern crate subtle;
 
 pub mod aead;
 mod ctr;
 pub mod siv;
+mod s2v;
 
 #[cfg(feature = "bench")]
 mod bench;

--- a/rust/src/s2v.rs
+++ b/rust/src/s2v.rs
@@ -1,0 +1,59 @@
+use crypto_mac::Mac;
+use dbl::Dbl;
+use generic_array::GenericArray;
+use generic_array::typenum::{U16, Unsigned};
+
+/// Maximum number of associated data items
+pub const MAX_ASSOCIATED_DATA: usize = 126;
+
+/// The S2V function performs a double-and-xor operation on the outputs
+/// of a pseudo-random function (CMAC or PMAC).
+///
+/// See Section 2.4 of RFC 5297 for more information
+pub fn s2v<M, I, T>(mac: &mut M, headers: I, message: &[u8]) -> GenericArray<u8, U16>
+where
+    M: Mac<OutputSize = U16>,
+    I: IntoIterator<Item = T>,
+    T: AsRef<[u8]>,
+{
+    mac.input(&GenericArray::<u8, M::OutputSize>::default());
+    let mut state = mac.result().code();
+
+    for (i, header) in headers.into_iter().enumerate() {
+        if i >= MAX_ASSOCIATED_DATA {
+            panic!("too many associated data items!");
+        }
+
+        state = state.dbl();
+        mac.input(header.as_ref());
+        let code = mac.result().code();
+        xor_in_place(&mut state, &code);
+    }
+
+    if message.len() >= M::OutputSize::to_usize() {
+        let n = message
+            .len()
+            .checked_sub(M::OutputSize::to_usize())
+            .unwrap();
+        mac.input(&message[..n]);
+        xor_in_place(&mut state, &message[n..]);
+    } else {
+        state = state.dbl();
+        xor_in_place(&mut state, message);
+        state[message.len()] ^= 0x80;
+    };
+
+    mac.input(state.as_ref());
+    mac.result().code()
+}
+
+/// XOR the second argument into the first in-place. Slices do not have to be
+/// aligned in memory.
+///
+/// Panics if the two slices aren't the same length
+#[inline]
+fn xor_in_place(a: &mut [u8], b: &[u8]) {
+    for i in 0..b.len() {
+        a[i] ^= b[i];
+    }
+}

--- a/rust/src/siv.rs
+++ b/rust/src/siv.rs
@@ -1,17 +1,14 @@
 //! `siv.rs`: The SIV misuse resistant block cipher mode of operation
 
 use aesni::{Aes128, Aes256};
-use block_cipher_trait::generic_array::GenericArray;
-use block_cipher_trait::generic_array::typenum::{U16, Unsigned};
 use cmac::Cmac;
 use crypto_mac::Mac;
 use ctr::{Aes128Ctr, Aes256Ctr, Ctr, IV_SIZE};
-use dbl::Dbl;
+use generic_array::GenericArray;
+use generic_array::typenum::{U16, Unsigned};
 use pmac::Pmac;
+use s2v::s2v;
 use subtle;
-
-/// Maximum number of associated data items
-pub const MAX_ASSOCIATED_DATA: usize = 126;
 
 /// The SIV misuse resistant block cipher mode of operation
 pub struct Siv<C: Ctr, M: Mac> {
@@ -28,7 +25,7 @@ pub type Aes256Siv = Siv<Aes256Ctr, Cmac<Aes256>>;
 /// AES-PMAC-SIV with a 128-bit key
 pub type Aes128PmacSiv = Siv<Aes128Ctr, Pmac<Aes128>>;
 
-/// AES-SIV with a 256-bit key
+/// AES-PMAC-SIV with a 256-bit key
 pub type Aes256PmacSiv = Siv<Aes256Ctr, Pmac<Aes256>>;
 
 impl<C: Ctr, M: Mac<OutputSize = U16>> Siv<C, M> {
@@ -87,11 +84,12 @@ impl<C: Ctr, M: Mac<OutputSize = U16>> Siv<C, M> {
         }
 
         // Compute the synthetic IV for this plaintext
-        let mut iv = self.s2v(associated_data, &plaintext[IV_SIZE..]);
-        plaintext[..IV_SIZE].copy_from_slice(&iv);
-
-        zero_iv_bits(&mut iv);
-        self.ctr.xor_in_place(&iv, &mut plaintext[IV_SIZE..]);
+        let iv = s2v(&mut self.mac, associated_data, &plaintext[IV_SIZE..]);
+        plaintext[..IV_SIZE].copy_from_slice(iv.as_slice());
+        self.ctr.xor_in_place(
+            &zero_iv_bits(&iv),
+            &mut plaintext[IV_SIZE..],
+        );
     }
 
     /// Decrypt the given ciphertext in-place, authenticating it against the
@@ -111,14 +109,11 @@ impl<C: Ctr, M: Mac<OutputSize = U16>> Siv<C, M> {
             return Err(());
         }
 
-        let mut iv = [0u8; IV_SIZE];
-        iv.copy_from_slice(&ciphertext[..IV_SIZE]);
-        zero_iv_bits(&mut iv);
-
+        let iv = zero_iv_bits(&ciphertext[..IV_SIZE]);
         self.ctr.xor_in_place(&iv, &mut ciphertext[IV_SIZE..]);
 
-        let actual_tag = self.s2v(associated_data, &ciphertext[IV_SIZE..]);
-        if subtle::slices_equal(&actual_tag, &ciphertext[..IV_SIZE]) != 1 {
+        let actual_tag = s2v(&mut self.mac, associated_data, &ciphertext[IV_SIZE..]);
+        if subtle::slices_equal(actual_tag.as_slice(), &ciphertext[..IV_SIZE]) != 1 {
             // Re-encrypt the decrypted plaintext to avoid revealing it
             self.ctr.xor_in_place(&iv, &mut ciphertext[IV_SIZE..]);
             return Err(());
@@ -126,65 +121,21 @@ impl<C: Ctr, M: Mac<OutputSize = U16>> Siv<C, M> {
 
         Ok(&ciphertext[IV_SIZE..])
     }
-
-    /// The S2V operation consists of the doubling and XORing of the outputs
-    /// of a pseudo-random function (CMAC or PMAC).
-    ///
-    /// See Section 2.4 of RFC 5297 for more information
-    fn s2v<I, T>(&mut self, associated_data: I, plaintext: &[u8]) -> [u8; IV_SIZE]
-    where
-        I: IntoIterator<Item = T>,
-        T: AsRef<[u8]>,
-    {
-        self.mac.input(&[0u8; IV_SIZE]);
-        let mut state = self.mac.result().code();
-
-        for (i, ad) in associated_data.into_iter().enumerate() {
-            if i >= MAX_ASSOCIATED_DATA {
-                panic!("too many associated data items!");
-            }
-
-            state = state.dbl();
-            self.mac.input(ad.as_ref());
-            let code = self.mac.result().code();
-            xor_in_place(&mut state, &code);
-        }
-
-        if plaintext.len() >= IV_SIZE {
-            let n = plaintext.len().checked_sub(IV_SIZE).unwrap();
-            self.mac.input(&plaintext[..n]);
-            xor_in_place(&mut state, &plaintext[n..]);
-        } else {
-            state = state.dbl();
-            xor_in_place(&mut state, plaintext);
-            state[plaintext.len()] ^= 0x80;
-        };
-
-        self.mac.input(state.as_ref());
-
-        let mut result = [0u8; IV_SIZE];
-        result.copy_from_slice(&self.mac.result().code());
-        result
-    }
-}
-
-/// XOR the second argument into the first in-place. Slices do not have to be
-/// aligned in memory.
-///
-/// Panics if the two slices aren't the same length
-#[inline]
-fn xor_in_place(a: &mut [u8], b: &[u8]) {
-    for i in 0..b.len() {
-        a[i] ^= b[i];
-    }
 }
 
 /// Zero out the top bits in the last 32-bit words of the IV
 #[inline]
-fn zero_iv_bits(block: &mut [u8; IV_SIZE]) {
+fn zero_iv_bits(iv: &[u8]) -> [u8; IV_SIZE] {
+    debug_assert_eq!(iv.len(), IV_SIZE, "wrong IV size: {}", iv.len());
+
+    let mut result = [0u8; IV_SIZE];
+    result.copy_from_slice(iv);
+
     // "We zero-out the top bit in each of the last two 32-bit words
     // of the IV before assigning it to Ctr"
     //  — http://web.cs.ucdavis.edu/~rogaway/papers/siv.pdf
-    block.as_mut()[8] &= 0x7f;
-    block.as_mut()[12] &= 0x7f;
+    result[8] &= 0x7f;
+    result[12] &= 0x7f;
+
+    result
 }

--- a/rust/tests/aead_test.rs
+++ b/rust/tests/aead_test.rs
@@ -3,8 +3,7 @@ extern crate miscreant;
 mod aead_vectors;
 
 use aead_vectors::AesSivAeadExample;
-use miscreant::aead::{Aes128SivAead, Aes256SivAead, Aes128PmacSivAead, Aes256PmacSivAead,
-                      Algorithm};
+use miscreant::aead::{Aes128Siv, Aes256Siv, Aes128PmacSiv, Aes256PmacSiv, Algorithm};
 
 const IV_SIZE: usize = 16;
 
@@ -21,11 +20,11 @@ fn aes_siv_aead_examples_seal() {
             "AES-SIV" => {
                 match example.key.len() {
                     32 => {
-                        let mut aead = Aes128SivAead::new(&example.key);
+                        let mut aead = Aes128Siv::new(&example.key);
                         aead.seal_in_place(&example.nonce, &example.ad, &mut buffer);
                     }
                     64 => {
-                        let mut aead = Aes256SivAead::new(&example.key);
+                        let mut aead = Aes256Siv::new(&example.key);
                         aead.seal_in_place(&example.nonce, &example.ad, &mut buffer);
                     }
                     _ => panic!("unexpected key size: {}", example.key.len()),
@@ -34,11 +33,11 @@ fn aes_siv_aead_examples_seal() {
             "AES-PMAC-SIV" => {
                 match example.key.len() {
                     32 => {
-                        let mut aead = Aes128PmacSivAead::new(&example.key);
+                        let mut aead = Aes128PmacSiv::new(&example.key);
                         aead.seal_in_place(&example.nonce, &example.ad, &mut buffer);
                     }
                     64 => {
-                        let mut aead = Aes256PmacSivAead::new(&example.key);
+                        let mut aead = Aes256PmacSiv::new(&example.key);
                         aead.seal_in_place(&example.nonce, &example.ad, &mut buffer);
                     }
                     _ => panic!("unexpected key size: {}", example.key.len()),


### PR DESCRIPTION
This should make it easier to reuse for other purposes (e.g. KDF)