### PR TITLE
rust: Replace macro-based AEAD implementation with a generic one

### DIFF
--- a/rust/src/aead.rs
+++ b/rust/src/aead.rs
@@ -2,9 +2,15 @@
 //! Symmetric encryption which ensures message confidentiality, integrity,
 //! and authenticity.
 
+use aesni::{Aes128, Aes256};
+use cmac::Cmac;
+use core::marker::PhantomData;
+use crypto_mac::Mac;
+use ctr::{Aes128Ctr, Aes256Ctr, Ctr};
 use generic_array::ArrayLength;
 use generic_array::typenum::{U16, U32, U64};
-use siv::{self, Siv};
+use pmac::Pmac;
+use siv::Siv;
 
 /// An AEAD algorithm
 pub trait Algorithm {
@@ -31,56 +37,50 @@ pub trait Algorithm {
     ) -> Result<&'a [u8], ()>;
 }
 
-/// Generate AEAD newtypes for SIV types
-macro_rules! impl_siv_aead {
-    ($name:ident, $key_size:ty, $doc:expr) => {
-        #[doc=$doc]
-        pub struct $name(siv::$name);
-
-        impl Algorithm for $name {
-            type KeySize = $key_size;
-            type TagSize = U16;
-
-            fn new(key: &[u8]) -> Self {
-                $name(Siv::new(key))
-            }
-
-            fn seal_in_place(&mut self, nonce: &[u8], associated_data: &[u8], buffer: &mut [u8]) {
-                self.0.seal_in_place(&[associated_data, nonce], buffer)
-            }
-
-            fn open_in_place<'a>(
-                &mut self,
-                nonce: &[u8],
-                associated_data: &[u8],
-                buffer: &'a mut [u8],
-            ) -> Result<&'a [u8], ()> {
-                self.0.open_in_place(&[associated_data, nonce], buffer)
-            }
-        }
-    }
+/// AEAD interface provider for AES-(PMAC-)SIV types
+pub struct SivAlgorithm<C: Ctr, M: Mac<OutputSize = U16>, K: ArrayLength<u8>> {
+    siv: Siv<C, M>,
+    key_size: PhantomData<K>,
 }
 
-impl_siv_aead!(
-    Aes128Siv,
-    U32,
-    "AES-CMAC-SIV in AEAD mode with 256-bit key size (128-bit security)"
-);
+/// AES-CMAC-SIV in AEAD mode with 256-bit key size (128-bit security)
+pub type Aes128Siv = SivAlgorithm<Aes128Ctr, Cmac<Aes128>, U32>;
 
-impl_siv_aead!(
-    Aes256Siv,
-    U64,
-    "AES-CMAC-SIV in AEAD mode with 512-bit key size (256-bit security)"
-);
+/// AES-CMAC-SIV in AEAD mode with 512-bit key size (256-bit security)
+pub type Aes256Siv = SivAlgorithm<Aes256Ctr, Cmac<Aes256>, U64>;
 
-impl_siv_aead!(
-    Aes128PmacSiv,
-    U32,
-    "AES-PMAC-SIV in AEAD mode with 256-bit key size (128-bit security"
-);
+/// AES-PMAC-SIV in AEAD mode with 256-bit key size (128-bit security)
+pub type Aes128PmacSiv = SivAlgorithm<Aes128Ctr, Pmac<Aes128>, U32>;
 
-impl_siv_aead!(
-    Aes256PmacSiv,
-    U64,
-    "AES-PMAC-SIV in AEAD mode with 512-bit key size (256-bit security)"
-);
+/// AES-PMAC-SIV in AEAD mode with 512-bit key size (256-bit security)
+pub type Aes256PmacSiv = SivAlgorithm<Aes256Ctr, Pmac<Aes256>, U64>;
+
+impl<C, M, K> Algorithm for SivAlgorithm<C, M, K>
+where
+    C: Ctr,
+    M: Mac<OutputSize = U16>,
+    K: ArrayLength<u8>,
+{
+    type KeySize = K;
+    type TagSize = U16;
+
+    fn new(key: &[u8]) -> Self {
+        Self {
+            siv: Siv::new(key),
+            key_size: PhantomData,
+        }
+    }
+
+    fn seal_in_place(&mut self, nonce: &[u8], associated_data: &[u8], buffer: &mut [u8]) {
+        self.siv.seal_in_place(&[associated_data, nonce], buffer)
+    }
+
+    fn open_in_place<'a>(
+        &mut self,
+        nonce: &[u8],
+        associated_data: &[u8],
+        buffer: &'a mut [u8],
+    ) -> Result<&'a [u8], ()> {
+        self.siv.open_in_place(&[associated_data, nonce], buffer)
+    }
+}


### PR DESCRIPTION
I cheated a bit with the initial AEAD implementation and used macros to define the various types.

This replaces it with a generic `SivAlgorithm` type which provides a generic implementation of `aead::Algorithm` for any `Siv` type.