### PR TITLE
rust: Add Buffer type

### DIFF
--- a/rust/src/buffer.rs
+++ b/rust/src/buffer.rs
@@ -1,0 +1,99 @@
+//! 'buffer.rs': A buffer type which handles slicing of AEAD messages
+
+use core::fmt;
+
+// TODO: use const generics when available
+const TAG_SIZE: usize = 16;
+
+/// A buffer type which handles taking slices of the message and tag portions
+/// of AEAD messages. Intended to make the in-place API slightly easier to work
+/// with and eliminate manual index calculations.
+pub struct Buffer<T: AsRef<[u8]> + AsMut<[u8]>>(T);
+
+// TODO: support for algorithms that place the tag at the end of the buffer
+// instead of the beginning. That's pretty much every AEAD scheme except
+// AES-SIV. Unfortunately AES-SIV is wacky that way.
+impl<T> Buffer<T>
+where
+    T: AsRef<[u8]> + AsMut<[u8]>,
+{
+    /// The entire message buffer as a slice
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+
+    /// The entire message buffer as a mutable slice
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+
+    /// Slice of the buffer containing the message (i.e. plaintext or untagged ciphertext)
+    pub fn msg_slice(&self) -> &[u8] {
+        &self.as_slice()[TAG_SIZE..]
+    }
+
+    /// Mutable slice of the buffer containing the message (i.e. plaintext or untagged ciphertext)
+    pub fn mut_msg_slice(&mut self) -> &mut [u8] {
+        &mut self.as_mut_slice()[TAG_SIZE..]
+    }
+
+    /// Slice of the buffer containing the message tag
+    pub fn tag_slice(&self) -> &[u8] {
+        &self.as_slice()[..TAG_SIZE]
+    }
+
+    /// Mutable slice of the buffer containing the message tag
+    pub fn mut_tag_slice(&mut self) -> &mut [u8] {
+        &mut self.as_mut_slice()[..TAG_SIZE]
+    }
+
+    /// Obtain the original value this buffer wraps
+    pub fn into_contents(self) -> T {
+        self.0
+    }
+}
+
+impl<T> From<T> for Buffer<T>
+where
+    T: AsRef<[u8]> + AsMut<[u8]>,
+{
+    /// Create a `Buffer` which wraps T.
+    /// Panics if T is too small to contain the MAC tag
+    fn from(value: T) -> Buffer<T> {
+        assert!(
+            value.as_ref().len() >= TAG_SIZE,
+            "expected length of at least {}, got {}",
+            TAG_SIZE,
+            value.as_ref().len()
+        );
+
+        Buffer(value)
+    }
+}
+
+impl<T> AsRef<[u8]> for Buffer<T>
+where
+    T: AsRef<[u8]> + AsMut<[u8]>,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl<T> AsMut<[u8]> for Buffer<T>
+where
+    T: AsRef<[u8]> + AsMut<[u8]>,
+{
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T> fmt::Debug for Buffer<T>
+where
+    T: AsRef<[u8]> + AsMut<[u8]>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "miscreant::Buffer {{ {:?} }}", self.as_slice())
+    }
+}

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,0 +1,13 @@
+//! `error.rs`: Miscreant's error type
+
+use core::fmt;
+
+/// An opaque error type, used for all errors in Miscreant
+#[derive(Debug, Eq, PartialEq)]
+pub struct Error;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "miscreant::error::Error")
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,10 +25,14 @@ extern crate pmac;
 extern crate subtle;
 
 pub mod aead;
+pub mod buffer;
 mod ctr;
+pub mod error;
 pub mod siv;
 mod s2v;
 pub mod stream;
 
 #[cfg(feature = "bench")]
 mod bench;
+
+pub use buffer::Buffer;

--- a/rust/src/s2v.rs
+++ b/rust/src/s2v.rs
@@ -1,3 +1,10 @@
+//! `s2v.rs`: a multi-message PRF construction built from a single-message PRF
+//!
+//! From "Deterministic Authenticated-Encryption: A Provable-Security Treatment
+//! of the Key-Wrap Problem"[1]
+//!
+//! [1]: http://web.cs.ucdavis.edu/~rogaway/papers/keywrap.pdf
+
 use crypto_mac::Mac;
 use dbl::Dbl;
 use generic_array::GenericArray;
@@ -6,10 +13,11 @@ use generic_array::typenum::{U16, Unsigned};
 /// Maximum number of associated data items
 pub const MAX_ASSOCIATED_DATA: usize = 126;
 
-/// The S2V function performs a double-and-xor operation on the outputs
-/// of a pseudo-random function (CMAC or PMAC).
+/// The S2V construction turns a pseudo-random function (e.g. CMAC, PMAC)
+/// into a PRF that acts on a sequence of messages.
 ///
-/// See Section 2.4 of RFC 5297 for more information
+/// It's used by the SIV construction to derive a synthetic initialization
+/// vector from zero or more message headers and the input plaintext.
 pub fn s2v<M, I, T>(mac: &mut M, headers: I, message: &[u8]) -> GenericArray<u8, U16>
 where
     M: Mac<OutputSize = U16>,

--- a/rust/src/siv.rs
+++ b/rust/src/siv.rs
@@ -1,9 +1,11 @@
 //! `siv.rs`: The SIV misuse resistant block cipher mode of operation
 
 use aesni::{Aes128, Aes256};
+use buffer::Buffer;
 use cmac::Cmac;
 use crypto_mac::Mac;
 use ctr::{Aes128Ctr, Aes256Ctr, Ctr, IV_SIZE};
+use error::Error;
 use generic_array::GenericArray;
 use generic_array::typenum::{U16, Unsigned};
 use pmac::Pmac;
@@ -54,41 +56,34 @@ impl<C: Ctr, M: Mac<OutputSize = U16>> Siv<C, M> {
     ///
     /// # Usage
     ///
-    /// It's important to note that only the *end* of the buffer will be
-    /// treated as the input plaintext:
+    /// The `miscreant::Buffer` type is intended to simplify slicing the buffer
+    /// into respective "message" and "tag" slices.
+    ///
+    /// The buffer must include an additional 16-bytes of space in which to
+    /// write the SIV tag (at the beginning of the buffer).
+    /// It's important to note that with AES-SIV the "tag" portion of the
+    /// buffer lies at the beginning, and the "message" portion at the end.
     ///
     /// ```rust
     /// let buffer = [0u8; 21];
     /// let plaintext = &buffer[..buffer.len() - 16];
     /// ```
     ///
-    /// In this case, only the *last* 5 bytes are treated as the plaintext,
-    /// since `21 - 16 = 5` (the AES block size is 16-bytes).
-    ///
-    /// The buffer must include an additional 16-bytes of space in which to
-    /// write the SIV tag (at the beginning of the buffer).
-    /// Failure to account for this will leave you with plaintext messages that
-    /// are missing their first 16-bytes!
-    ///
     /// # Panics
     ///
-    /// Panics if `plaintext.len()` is less than `M::OutputSize`.
     /// Panics if `associated_data.len()` is greater than `MAX_ASSOCIATED_DATA`.
-    pub fn seal_in_place<I, T>(&mut self, associated_data: I, plaintext: &mut [u8])
+    pub fn seal_in_place<B, I, T>(&mut self, associated_data: I, buf: &mut Buffer<B>)
     where
+        B: AsRef<[u8]> + AsMut<[u8]>,
         I: IntoIterator<Item = T>,
         T: AsRef<[u8]>,
     {
-        if plaintext.len() < IV_SIZE {
-            panic!("plaintext buffer too small to hold MAC tag!");
-        }
-
         // Compute the synthetic IV for this plaintext
-        let iv = s2v(&mut self.mac, associated_data, &plaintext[IV_SIZE..]);
-        plaintext[..IV_SIZE].copy_from_slice(iv.as_slice());
+        let siv = s2v(&mut self.mac, associated_data, buf.msg_slice());
+        buf.mut_tag_slice().copy_from_slice(siv.as_slice());
         self.ctr.xor_in_place(
-            &zero_iv_bits(&iv),
-            &mut plaintext[IV_SIZE..],
+            &zero_iv_bits(&siv),
+            buf.mut_msg_slice(),
         );
     }
 
@@ -96,30 +91,27 @@ impl<C: Ctr, M: Mac<OutputSize = U16>> Siv<C, M> {
     /// synthetic IV included in the message.
     ///
     /// Returns a slice containing a decrypted message on success.
-    pub fn open_in_place<'a, I, T>(
+    pub fn open_in_place<B, I, T>(
         &mut self,
         associated_data: I,
-        ciphertext: &'a mut [u8],
-    ) -> Result<&'a [u8], ()>
+        buf: &mut Buffer<B>,
+    ) -> Result<(), Error>
     where
+        B: AsRef<[u8]> + AsMut<[u8]>,
         I: IntoIterator<Item = T>,
         T: AsRef<[u8]>,
     {
-        if ciphertext.len() < IV_SIZE {
-            return Err(());
+        let iv = zero_iv_bits(buf.tag_slice());
+        self.ctr.xor_in_place(&iv, buf.mut_msg_slice());
+
+        let computed_tag = s2v(&mut self.mac, associated_data, buf.msg_slice());
+        if subtle::slices_equal(computed_tag.as_slice(), buf.tag_slice()) != 1 {
+            // On verify fail, re-encrypt the unauthenticated plaintext to avoid revealing it
+            self.ctr.xor_in_place(&iv, buf.mut_msg_slice());
+            return Err(Error);
         }
 
-        let iv = zero_iv_bits(&ciphertext[..IV_SIZE]);
-        self.ctr.xor_in_place(&iv, &mut ciphertext[IV_SIZE..]);
-
-        let actual_tag = s2v(&mut self.mac, associated_data, &ciphertext[IV_SIZE..]);
-        if subtle::slices_equal(actual_tag.as_slice(), &ciphertext[..IV_SIZE]) != 1 {
-            // Re-encrypt the decrypted plaintext to avoid revealing it
-            self.ctr.xor_in_place(&iv, &mut ciphertext[IV_SIZE..]);
-            return Err(());
-        }
-
-        Ok(&ciphertext[IV_SIZE..])
+        Ok(())
     }
 }
 

--- a/rust/src/stream.rs
+++ b/rust/src/stream.rs
@@ -2,7 +2,9 @@
 //! See <https://eprint.iacr.org/2015/189.pdf> for definition.
 
 use aead::{self, Aes128Siv, Aes128PmacSiv, Aes256Siv, Aes256PmacSiv};
+use buffer::Buffer;
 use byteorder::{BigEndian, ByteOrder};
+use error::Error;
 
 /// Size of a nonce required by STREAM in bytes
 pub const NONCE_SIZE: usize = 8;
@@ -47,13 +49,19 @@ impl<A: aead::Algorithm> Encryptor<A> {
     }
 
     /// Encrypt the next message in the stream in-place
-    pub fn seal_next_in_place(&mut self, ad: &[u8], buffer: &mut [u8]) {
+    pub fn seal_next_in_place<B>(&mut self, ad: &[u8], buffer: &mut Buffer<B>)
+    where
+        B: AsRef<[u8]> + AsMut<[u8]>,
+    {
         self.alg.seal_in_place(self.nonce.as_slice(), ad, buffer);
         self.nonce.increment();
     }
 
     /// Encrypt the final message in-place, consuming the stream encryptor
-    pub fn seal_last_in_place(mut self, ad: &[u8], buffer: &mut [u8]) {
+    pub fn seal_last_in_place<B>(mut self, ad: &[u8], buffer: &mut Buffer<B>)
+    where
+        B: AsRef<[u8]> + AsMut<[u8]>,
+    {
         self.alg.seal_in_place(&self.nonce.finish(), ad, buffer);
     }
 }
@@ -95,22 +103,20 @@ impl<A: aead::Algorithm> Decryptor<A> {
     }
 
     /// Decrypt the next message in the stream in-place
-    pub fn open_next_in_place<'a>(
-        &mut self,
-        ad: &[u8],
-        buffer: &'a mut [u8],
-    ) -> Result<&'a [u8], ()> {
-        let result = self.alg.open_in_place(self.nonce.as_slice(), ad, buffer)?;
+    pub fn open_next_in_place<B>(&mut self, ad: &[u8], buffer: &mut Buffer<B>) -> Result<(), Error>
+    where
+        B: AsRef<[u8]> + AsMut<[u8]>,
+    {
+        self.alg.open_in_place(self.nonce.as_slice(), ad, buffer)?;
         self.nonce.increment();
-        Ok(result)
+        Ok(())
     }
 
     /// Decrypt the final message in-place, consuming the stream decryptor
-    pub fn open_last_in_place<'a>(
-        mut self,
-        ad: &[u8],
-        buffer: &'a mut [u8],
-    ) -> Result<&'a [u8], ()> {
+    pub fn open_last_in_place<B>(mut self, ad: &[u8], buffer: &mut Buffer<B>) -> Result<(), Error>
+    where
+        B: AsRef<[u8]> + AsMut<[u8]>,
+    {
         self.alg.open_in_place(&self.nonce.finish(), ad, buffer)
     }
 }

--- a/rust/tests/aead_test.rs
+++ b/rust/tests/aead_test.rs
@@ -3,6 +3,7 @@ extern crate miscreant;
 mod aead_vectors;
 
 use aead_vectors::AesSivAeadExample;
+use miscreant::Buffer;
 use miscreant::aead::{Aes128Siv, Aes256Siv, Aes128PmacSiv, Aes256PmacSiv, Algorithm};
 
 const IV_SIZE: usize = 16;
@@ -12,8 +13,8 @@ fn aes_siv_aead_examples_seal() {
     let examples = AesSivAeadExample::load_all();
 
     for example in examples {
-        let mut buffer = vec![0; example.plaintext.len() + IV_SIZE];
-        buffer[IV_SIZE..].copy_from_slice(&example.plaintext);
+        let mut buffer = Buffer::from(vec![0; example.plaintext.len() + IV_SIZE]);
+        buffer.mut_msg_slice().copy_from_slice(&example.plaintext);
 
         match example.alg.as_ref() {
             "AES-SIV" => {
@@ -45,7 +46,7 @@ fn aes_siv_aead_examples_seal() {
             _ => panic!("unexpected algorithm: {}", example.alg),
         }
 
-        assert_eq!(buffer, example.ciphertext);
+        assert_eq!(buffer.as_slice(), example.ciphertext.as_slice());
     }
 }
 
@@ -54,8 +55,9 @@ fn aes_siv_aead_examples_open() {
     let examples = AesSivAeadExample::load_all();
 
     for example in examples {
-        let mut buffer = example.ciphertext.clone();
-        let result = match example.alg.as_ref() {
+        let mut buffer = Buffer::from(example.ciphertext.clone());
+
+        match example.alg.as_ref() {
             "AES-SIV" => {
                 match example.key.len() {
                     32 => {
@@ -89,6 +91,6 @@ fn aes_siv_aead_examples_open() {
             _ => panic!("unexpected algorithm: {}", example.alg),
         };
 
-        assert_eq!(result, example.plaintext.as_slice());
+        assert_eq!(buffer.msg_slice(), example.plaintext.as_slice());
     }
 }

--- a/rust/tests/siv_test.rs
+++ b/rust/tests/siv_test.rs
@@ -2,6 +2,7 @@ extern crate miscreant;
 
 mod siv_vectors;
 
+use miscreant::Buffer;
 use miscreant::siv::{Aes128Siv, Aes256Siv, Aes128PmacSiv, Aes256PmacSiv};
 use siv_vectors::{AesSivExample, AesPmacSivExample};
 
@@ -13,8 +14,8 @@ fn aes_siv_examples_seal() {
 
     for example in examples {
         let len = example.plaintext.len();
-        let mut buffer = vec![0; len + IV_SIZE];
-        buffer[IV_SIZE..].copy_from_slice(&example.plaintext);
+        let mut buffer = Buffer::from(vec![0; len + IV_SIZE]);
+        buffer.mut_msg_slice().copy_from_slice(&example.plaintext);
 
         match example.key.len() {
             32 => {
@@ -28,7 +29,7 @@ fn aes_siv_examples_seal() {
             _ => panic!("unexpected key size: {}", example.key.len()),
         };
 
-        assert_eq!(buffer, example.ciphertext);
+        assert_eq!(buffer.as_slice(), example.ciphertext.as_slice());
     }
 }
 
@@ -37,9 +38,9 @@ fn aes_siv_examples_open() {
     let examples = AesSivExample::load_all();
 
     for example in examples {
-        let mut buffer = example.ciphertext.clone();
+        let mut buffer = Buffer::from(example.ciphertext.clone());
 
-        let plaintext = match example.key.len() {
+        match example.key.len() {
             32 => {
                 let mut siv = Aes128Siv::new(&example.key);
                 siv.open_in_place(&example.ad, &mut buffer)
@@ -51,7 +52,7 @@ fn aes_siv_examples_open() {
             _ => panic!("unexpected key size: {}", example.key.len()),
         }.expect("successful decrypt");
 
-        assert_eq!(plaintext, &example.plaintext[..]);
+        assert_eq!(buffer.msg_slice(), example.plaintext.as_slice());
     }
 }
 
@@ -61,8 +62,8 @@ fn aes_pmac_siv_examples_seal() {
 
     for example in examples {
         let len = example.plaintext.len();
-        let mut buffer = vec![0; len + IV_SIZE];
-        buffer[IV_SIZE..].copy_from_slice(&example.plaintext);
+        let mut buffer = Buffer::from(vec![0; len + IV_SIZE]);
+        buffer.mut_msg_slice().copy_from_slice(&example.plaintext);
 
         match example.key.len() {
             32 => {
@@ -76,7 +77,7 @@ fn aes_pmac_siv_examples_seal() {
             _ => panic!("unexpected key size: {}", example.key.len()),
         };
 
-        assert_eq!(buffer, example.ciphertext);
+        assert_eq!(buffer.as_slice(), example.ciphertext.as_slice());
     }
 }
 
@@ -85,9 +86,9 @@ fn aes_pmac_siv_examples_open() {
     let examples = AesPmacSivExample::load_all();
 
     for example in examples {
-        let mut buffer = example.ciphertext.clone();
+        let mut buffer = Buffer::from(example.ciphertext.clone());
 
-        let plaintext = match example.key.len() {
+        match example.key.len() {
             32 => {
                 let mut siv = Aes128PmacSiv::new(&example.key);
                 siv.open_in_place(&example.ad, &mut buffer)
@@ -99,6 +100,6 @@ fn aes_pmac_siv_examples_open() {
             _ => panic!("unexpected key size: {}", example.key.len()),
         }.expect("successful decrypt");
 
-        assert_eq!(plaintext, &example.plaintext[..]);
+        assert_eq!(buffer.msg_slice(), example.plaintext.as_slice());
     }
 }


### PR DESCRIPTION
Buffer is a wrapper type for SIV message slices, which handles slicing them into the IV/tag portion and the plaintext/ciphertext portion.