### PR TITLE
rust: "std" feature and allocating APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,7 @@ matrix:
   - language: rust
     rust: nightly
     before_script: cd rust
-
+  - language: rust
+    rust: nightly
+    before_script: cd rust
+    script: cargo build --no-default-features

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,6 +29,8 @@ serde_json = "1"
 
 [features]
 bench = ["ring"]
+default = ["std"]
+std = []
 
 [profile.bench]
 opt-level = 3

--- a/rust/src/aead.rs
+++ b/rust/src/aead.rs
@@ -41,6 +41,27 @@ pub trait Algorithm {
     ) -> Result<(), Error>
     where
         B: AsRef<[u8]> + AsMut<[u8]>;
+
+    /// Encrypt the given plaintext, allocating and returning a Vec<u8> for the ciphertext
+    #[cfg(feature = "std")]
+    fn seal(&mut self, nonce: &[u8], associated_data: &[u8], plaintext: &[u8]) -> Vec<u8> {
+        let mut buf = Buffer::from_plaintext(plaintext);
+        self.seal_in_place(nonce, associated_data, &mut buf);
+        buf.into_contents()
+    }
+
+    /// Decrypt the given ciphertext, allocating and returning a Vec<u8> for the plaintext
+    #[cfg(feature = "std")]
+    fn open(
+        &mut self,
+        nonce: &[u8],
+        associated_data: &[u8],
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>, Error> {
+        let mut buf = Buffer::from(Vec::from(ciphertext));
+        self.open_in_place(nonce, associated_data, &mut buf)?;
+        Ok(buf.into_plaintext())
+    }
 }
 
 /// AEAD interface provider for AES-(PMAC-)SIV types

--- a/rust/src/buffer.rs
+++ b/rust/src/buffer.rs
@@ -53,6 +53,27 @@ where
     }
 }
 
+#[cfg(feature = "std")]
+impl Buffer<Vec<u8>> {
+    /// Allocate a Vec-backed buffer which makes a copy of the message
+    /// plaintext with additional space for the tag
+    pub fn from_plaintext(plaintext: &[u8]) -> Self {
+        let mut buffer = Buffer::from(vec![0; TAG_SIZE + plaintext.len()]);
+        buffer.mut_msg_slice().copy_from_slice(plaintext);
+        buffer
+    }
+
+    /// Consumes the `Buffer` and returns a `Vec<u8>` containing only the
+    /// message portion of the buffer, sans the IV/tag
+    ///
+    /// NOTE: does not actually decrypt the buffer
+    pub fn into_plaintext(self) -> Vec<u8> {
+        let mut plaintext = self.into_contents();
+        plaintext.drain(..TAG_SIZE);
+        plaintext
+    }
+}
+
 impl<T> From<T> for Buffer<T>
 where
     T: AsRef<[u8]> + AsMut<[u8]>,

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -2,12 +2,23 @@
 
 use core::fmt;
 
+/// How to display the error type in messages
+const DISPLAY_STRING: &str = "miscreant::error::Error";
+
 /// An opaque error type, used for all errors in Miscreant
 #[derive(Debug, Eq, PartialEq)]
 pub struct Error;
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "miscreant::error::Error")
+        write!(f, "{}", DISPLAY_STRING)
+    }
+}
+
+#[cfg(feature = "std")]
+impl ::std::error::Error for Error {
+    #[inline]
+    fn description(&self) -> &str {
+        DISPLAY_STRING
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,11 +7,8 @@
 #![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 
-#![no_std]
-
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "bench", feature(test))]
-#[cfg(all(feature = "bench", test))]
-extern crate test;
 
 extern crate aesni;
 extern crate byteorder;
@@ -24,8 +21,14 @@ extern crate generic_array;
 extern crate pmac;
 extern crate subtle;
 
+#[cfg(feature = "std")]
+extern crate core;
+
+#[cfg(all(feature = "bench", test))]
+extern crate test;
+
 pub mod aead;
-pub mod buffer;
+mod buffer;
 mod ctr;
 pub mod error;
 pub mod siv;

--- a/rust/src/siv.rs
+++ b/rust/src/siv.rs
@@ -113,6 +113,30 @@ impl<C: Ctr, M: Mac<OutputSize = U16>> Siv<C, M> {
 
         Ok(())
     }
+
+    /// Encrypt the given plaintext, allocating and returning a Vec<u8> for the ciphertext
+    #[cfg(feature = "std")]
+    pub fn seal<I, T>(&mut self, associated_data: I, plaintext: &[u8]) -> Vec<u8>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<[u8]>,
+    {
+        let mut buf = Buffer::from_plaintext(plaintext);
+        self.seal_in_place(associated_data, &mut buf);
+        buf.into_contents()
+    }
+
+    /// Decrypt the given ciphertext, allocating and returning a Vec<u8> for the plaintext
+    #[cfg(feature = "std")]
+    pub fn open<I, T>(&mut self, associated_data: I, ciphertext: &[u8]) -> Result<Vec<u8>, Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<[u8]>,
+    {
+        let mut buf = Buffer::from(Vec::from(ciphertext));
+        self.open_in_place(associated_data, &mut buf)?;
+        Ok(buf.into_plaintext())
+    }
 }
 
 /// Zero out the top bits in the last 32-bit words of the IV

--- a/rust/tests/siv_test.rs
+++ b/rust/tests/siv_test.rs
@@ -2,34 +2,21 @@ extern crate miscreant;
 
 mod siv_vectors;
 
-use miscreant::Buffer;
 use miscreant::siv::{Aes128Siv, Aes256Siv, Aes128PmacSiv, Aes256PmacSiv};
 use siv_vectors::{AesSivExample, AesPmacSivExample};
-
-const IV_SIZE: usize = 16;
 
 #[test]
 fn aes_siv_examples_seal() {
     let examples = AesSivExample::load_all();
 
     for example in examples {
-        let len = example.plaintext.len();
-        let mut buffer = Buffer::from(vec![0; len + IV_SIZE]);
-        buffer.mut_msg_slice().copy_from_slice(&example.plaintext);
-
-        match example.key.len() {
-            32 => {
-                let mut siv = Aes128Siv::new(&example.key);
-                siv.seal_in_place(&example.ad, &mut buffer);
-            }
-            64 => {
-                let mut siv = Aes256Siv::new(&example.key);
-                siv.seal_in_place(&example.ad, &mut buffer);
-            }
+        let ciphertext = match example.key.len() {
+            32 => Aes128Siv::new(&example.key).seal(&example.ad, &example.plaintext),
+            64 => Aes256Siv::new(&example.key).seal(&example.ad, &example.plaintext),
             _ => panic!("unexpected key size: {}", example.key.len()),
         };
 
-        assert_eq!(buffer.as_slice(), example.ciphertext.as_slice());
+        assert_eq!(ciphertext, example.ciphertext);
     }
 }
 
@@ -38,21 +25,13 @@ fn aes_siv_examples_open() {
     let examples = AesSivExample::load_all();
 
     for example in examples {
-        let mut buffer = Buffer::from(example.ciphertext.clone());
-
-        match example.key.len() {
-            32 => {
-                let mut siv = Aes128Siv::new(&example.key);
-                siv.open_in_place(&example.ad, &mut buffer)
-            }
-            64 => {
-                let mut siv = Aes256Siv::new(&example.key);
-                siv.open_in_place(&example.ad, &mut buffer)
-            }
+        let plaintext = match example.key.len() {
+            32 => Aes128Siv::new(&example.key).open(&example.ad, &example.ciphertext),
+            64 => Aes256Siv::new(&example.key).open(&example.ad, &example.ciphertext),
             _ => panic!("unexpected key size: {}", example.key.len()),
-        }.expect("successful decrypt");
+        }.expect("decrypt failure");
 
-        assert_eq!(buffer.msg_slice(), example.plaintext.as_slice());
+        assert_eq!(plaintext, example.plaintext);
     }
 }
 
@@ -61,23 +40,13 @@ fn aes_pmac_siv_examples_seal() {
     let examples = AesPmacSivExample::load_all();
 
     for example in examples {
-        let len = example.plaintext.len();
-        let mut buffer = Buffer::from(vec![0; len + IV_SIZE]);
-        buffer.mut_msg_slice().copy_from_slice(&example.plaintext);
-
-        match example.key.len() {
-            32 => {
-                let mut siv = Aes128PmacSiv::new(&example.key);
-                siv.seal_in_place(&example.ad, &mut buffer);
-            }
-            64 => {
-                let mut siv = Aes256PmacSiv::new(&example.key);
-                siv.seal_in_place(&example.ad, &mut buffer);
-            }
+        let ciphertext = match example.key.len() {
+            32 => Aes128PmacSiv::new(&example.key).seal(&example.ad, &example.plaintext),
+            64 => Aes256PmacSiv::new(&example.key).seal(&example.ad, &example.plaintext),
             _ => panic!("unexpected key size: {}", example.key.len()),
         };
 
-        assert_eq!(buffer.as_slice(), example.ciphertext.as_slice());
+        assert_eq!(ciphertext, example.ciphertext);
     }
 }
 
@@ -86,20 +55,12 @@ fn aes_pmac_siv_examples_open() {
     let examples = AesPmacSivExample::load_all();
 
     for example in examples {
-        let mut buffer = Buffer::from(example.ciphertext.clone());
-
-        match example.key.len() {
-            32 => {
-                let mut siv = Aes128PmacSiv::new(&example.key);
-                siv.open_in_place(&example.ad, &mut buffer)
-            }
-            64 => {
-                let mut siv = Aes256PmacSiv::new(&example.key);
-                siv.open_in_place(&example.ad, &mut buffer)
-            }
+        let plaintext = match example.key.len() {
+            32 => Aes128PmacSiv::new(&example.key).open(&example.ad, &example.ciphertext),
+            64 => Aes256PmacSiv::new(&example.key).open(&example.ad, &example.ciphertext),
             _ => panic!("unexpected key size: {}", example.key.len()),
-        }.expect("successful decrypt");
+        }.expect("decrypt failure");
 
-        assert_eq!(buffer.msg_slice(), example.plaintext.as_slice());
+        assert_eq!(plaintext, example.plaintext);
     }
 }

--- a/rust/tests/stream_test.rs
+++ b/rust/tests/stream_test.rs
@@ -3,15 +3,13 @@ extern crate generic_array;
 
 mod stream_vectors;
 
-use miscreant::{aead, Buffer};
+use miscreant::aead;
 use miscreant::stream::{Aes128PmacSivEncryptor, Aes128PmacSivDecryptor};
 use miscreant::stream::{Aes128SivEncryptor, Aes128SivDecryptor};
 use miscreant::stream::{Aes256PmacSivEncryptor, Aes256PmacSivDecryptor};
 use miscreant::stream::{Aes256SivEncryptor, Aes256SivDecryptor};
 use miscreant::stream::{Encryptor, Decryptor};
 use stream_vectors::{AesSivStreamExample, Block};
-
-const IV_SIZE: usize = 16;
 
 #[test]
 fn aes_siv_stream_examples_seal() {
@@ -42,15 +40,12 @@ fn aes_siv_stream_examples_seal() {
 
 fn test_encryptor<A: aead::Algorithm>(mut encryptor: Encryptor<A>, blocks: &[Block]) {
     for (i, block) in blocks.iter().enumerate() {
-        let mut buffer = Buffer::from(vec![0; IV_SIZE + block.plaintext.len()]);
-        buffer.mut_msg_slice().copy_from_slice(&block.plaintext);
-
         if i < blocks.len() - 1 {
-            encryptor.seal_next_in_place(&block.ad, &mut buffer);
-            assert_eq!(buffer.as_slice(), block.ciphertext.as_slice());
+            let ciphertext = encryptor.seal_next(&block.ad, &block.plaintext);
+            assert_eq!(ciphertext, block.ciphertext);
         } else {
-            encryptor.seal_last_in_place(&block.ad, &mut buffer);
-            assert_eq!(buffer.as_slice(), block.ciphertext.as_slice());
+            let ciphertext = encryptor.seal_last(&block.ad, &block.plaintext);
+            assert_eq!(ciphertext, block.ciphertext);
             return;
         }
     }
@@ -85,20 +80,18 @@ fn aes_siv_stream_examples_open() {
 
 fn test_decryptor<A: aead::Algorithm>(mut decryptor: Decryptor<A>, blocks: &[Block]) {
     for (i, block) in blocks.iter().enumerate() {
-        let mut buffer = Buffer::from(block.ciphertext.clone());
-
         if i < blocks.len() - 1 {
-            decryptor
-                .open_next_in_place(&block.ad, &mut buffer)
-                .expect("decrypt failure");
+            let plaintext = decryptor.open_next(&block.ad, &block.ciphertext).expect(
+                "decrypt failure",
+            );
 
-            assert_eq!(buffer.msg_slice(), block.plaintext.as_slice());
+            assert_eq!(plaintext, block.plaintext);
         } else {
-            decryptor
-                .open_last_in_place(&block.ad, &mut buffer)
-                .expect("decrypt failure");
+            let plaintext = decryptor.open_last(&block.ad, &block.ciphertext).expect(
+                "decrypt failure",
+            );
 
-            assert_eq!(buffer.msg_slice(), block.plaintext.as_slice());
+            assert_eq!(plaintext, block.plaintext);
             return;
         }
     }


### PR DESCRIPTION
Adds a set of allocating APIs that correspond to each of the existing APIs, gated on an enabled-by-default "std" feature.

Uses these APIs in tests, which exercises both codepaths, and also makes the tests cleaner.