### PR TITLE
ruby: STREAM implementation

### DIFF
--- a/ruby/lib/miscreant.rb
+++ b/ruby/lib/miscreant.rb
@@ -5,11 +5,13 @@ require "openssl"
 require "securerandom"
 
 require "miscreant/version"
+
 require "miscreant/aead"
 require "miscreant/aes/cmac"
 require "miscreant/aes/pmac"
 require "miscreant/aes/siv"
 require "miscreant/internals"
+require "miscreant/stream"
 
 # Miscreant: A misuse-resistant symmetric encryption library
 module Miscreant
@@ -18,6 +20,9 @@ module Miscreant
 
   # Ciphertext failed to verify as authentic
   IntegrityError = Class.new(CryptoError)
+
+  # Integer value overflowed
+  OverflowError = Class.new(StandardError)
 
   # Hide internals from the outside world
   private_constant :Internals

--- a/ruby/lib/miscreant/stream.rb
+++ b/ruby/lib/miscreant/stream.rb
@@ -1,0 +1,132 @@
+# encoding: binary
+# frozen_string_literal: true
+
+module Miscreant
+  # The STREAM online authenticated encryption construction.
+  # See <https://eprint.iacr.org/2015/189.pdf> for definition.
+  #
+  # Miscreant's implementation of STREAM uses an 8-byte (64-bit) nonce
+  # prefix along with a 32-bit counter and 1-byte "last block" flag
+  module STREAM
+    # Size of a nonce required by STREAM in bytes
+    NONCE_SIZE = 8
+
+    # Byte flag indicating this is the last block in the STREAM (otherwise 0)
+    LAST_BLOCK_FLAG = 1
+
+    # Maximum value of the STREAM counter
+    COUNTER_MAX = 2**32
+
+    # Raised if we attempt to continue an already-finished STREAM
+    FinishedError = Class.new(StandardError)
+
+    # A STREAM encryptor
+    #
+    # This corresponds to the ℰ stream encryptor object as defined in the paper
+    # Online Authenticated-Encryption and its Nonce-Reuse Misuse-Resistance
+    class Encryptor
+      # Create a new STREAM encryptor.
+      #
+      # @param alg ["AES-SIV", "AES-PMAC-SIV"] cryptographic algorithm to use
+      # @param key [String] 32-byte or 64-byte random Encoding::BINARY secret key
+      # @param nonce [String] 8-byte nonce
+      #
+      # @raise [TypeError] nonce is not a String
+      # @raise [ArgumentError] nonce is wrong length or not Encoding::BINARY
+      def initialize(alg, key, nonce)
+        @aead = AEAD.new(alg, key)
+        @nonce_encoder = NonceEncoder.new(nonce)
+      end
+
+      # Encrypt the next message in the stream
+      #
+      # @param plaintext [String] plaintext message to encrypt
+      # @param ad [String] (optional) associated data to authenticate
+      # @param last_block [true, false] is this the last block in the STREAM?
+      #
+      # @return [String] ciphertext message
+      def seal(plaintext, ad: "", last_block: false)
+        @aead.seal(plaintext, nonce: @nonce_encoder.next(last_block), ad: ad)
+      end
+
+      # Inspect this STREAM encryptor instance
+      #
+      # @return [String] description of this instance
+      def inspect
+        to_s
+      end
+    end
+
+    # A STREAM decryptor
+    #
+    # This corresponds to the 𝒟 stream decryptor object as defined in the paper
+    # Online Authenticated-Encryption and its Nonce-Reuse Misuse-Resistance
+    class Decryptor
+      # Create a new STREAM decryptor.
+      #
+      # @param alg ["AES-SIV", "AES-PMAC-SIV"] cryptographic algorithm to use
+      # @param key [String] 32-byte or 64-byte random Encoding::BINARY secret key
+      # @param nonce [String] 8-byte nonce
+      #
+      # @raise [TypeError] nonce is not a String
+      # @raise [ArgumentError] nonce is wrong length or not Encoding::BINARY
+      def initialize(alg, key, nonce)
+        @aead = AEAD.new(alg, key)
+        @nonce_encoder = NonceEncoder.new(nonce)
+      end
+
+      # Decrypt the next message in the stream
+      #
+      # @param ciphertext [String] cipher message to encrypt
+      # @param ad [String] (optional) associated data to authenticate
+      # @param last_block [true, false] is this the last block in the STREAM?
+      #
+      # @raise [Miscreant::IntegrityError] ciphertext and/or associated data are corrupt or tampered with
+      # @return [String] plaintext message
+      def open(ciphertext, ad: "", last_block: false)
+        @aead.open(ciphertext, nonce: @nonce_encoder.next(last_block), ad: ad)
+      end
+
+      # Inspect this STREAM encryptor instance
+      #
+      # @return [String] description of this instance
+      def inspect
+        to_s
+      end
+    end
+
+    # Computes STREAM nonces based on the current position in the STREAM.
+    class NonceEncoder
+      # Create a new nonce encoder with the given prefix
+      #
+      # @param [nonce_prefix] 64-bit string used as the STREAM nonce prefix
+      #
+      # @raise [TypeError] nonce prefix is not a String
+      # @raise [ArgumentError] nonce prefix is wrong length or not Encoding::BINARY
+      def initialize(nonce_prefix)
+        Internals::Util.validate_bytestring("nonce", nonce_prefix, length: NONCE_SIZE)
+        @nonce_prefix = nonce_prefix
+        @counter = 0
+        @finished = false
+      end
+
+      # Obtain the next nonce in the stream
+      #
+      # @param last_block [true, false] is this the last block?
+      #
+      # @return [String] encoded STREAM nonce
+      def next(last_block)
+        raise FinishedError, "STREAM is already finished" if @finished
+        @finished = last_block
+
+        encoded_nonce = [@nonce_prefix, @counter, last_block ? LAST_BLOCK_FLAG : 0].pack("a8NC")
+        @counter += 1
+        raise OverflowError, "STREAM counter overflowed" if @counter >= 2**64
+
+        encoded_nonce
+      end
+    end
+
+    private_constant :NonceEncoder
+  end
+end

--- a/ruby/spec/miscreant/stream_spec.rb
+++ b/ruby/spec/miscreant/stream_spec.rb
@@ -1,0 +1,36 @@
+# encoding: binary
+# frozen_string_literal: true
+
+RSpec.describe Miscreant::STREAM do
+  let(:test_vectors) { Miscreant::STREAM::Example.load_file }
+
+  context "Encryptor" do
+    describe "seal" do
+      it "passes all STREAM test vectors" do
+        test_vectors.each do |ex|
+          stream = Miscreant::STREAM::Encryptor.new(ex.alg, ex.key, ex.nonce)
+
+          ex.blocks.each_with_index do |block, i|
+            ciphertext = stream.seal(block.plaintext, ad: block.ad, last_block: i + 1 == ex.blocks.size)
+            expect(ciphertext).to eq(block.ciphertext)
+          end
+        end
+      end
+    end
+  end
+
+  context "Decryptor" do
+    describe "open" do
+      it "passes all STREAM test vectors" do
+        test_vectors.each do |ex|
+          stream = Miscreant::STREAM::Decryptor.new(ex.alg, ex.key, ex.nonce)
+
+          ex.blocks.each_with_index do |block, i|
+            plaintext = stream.open(block.ciphertext, ad: block.ad, last_block: i + 1 == ex.blocks.size)
+            expect(plaintext).to eq(block.plaintext)
+          end
+        end
+      end
+    end
+  end
+end

--- a/ruby/spec/support/test_vectors.rb
+++ b/ruby/spec/support/test_vectors.rb
@@ -145,6 +145,32 @@ class Miscreant::AEAD::Example
   end
 end
 
+class Miscreant::STREAM::Example
+  attr_reader :name, :alg, :key, :nonce, :blocks
+
+  # Default file to load examples from
+  DEFAULT_EXAMPLES = File.expand_path("../../../../vectors/aes_siv_stream.tjson", __FILE__)
+
+  Block = Struct.new(:ad, :plaintext, :ciphertext)
+
+  def self.load_file(filename = DEFAULT_EXAMPLES)
+    examples = TJSON.load_file(filename).fetch("examples")
+    raise ParseError, "expected a toplevel array of examples" unless examples.is_a?(Array)
+
+    examples.map { |example| new(example) }
+  end
+
+  def initialize(attrs)
+    @name = attrs.fetch("name")
+    @alg = attrs.fetch("alg")
+    @key = attrs.fetch("key")
+    @nonce = attrs.fetch("nonce")
+    @blocks = attrs.fetch("blocks").map do |block|
+      Block.new(block.fetch("ad"), block.fetch("plaintext"), block.fetch("ciphertext"))
+    end
+  end
+end
+
 class DblExample
   attr_reader :input, :output
 


### PR DESCRIPTION
Implements the STREAM construction for online authenticated encryption as described in the paper "Online Authenticated-Encryption and its Nonce-Reuse Misuse-Resistance"[1]

This implementation is tested against the in-repo test vectors originally generated from the Rust implementation.

[1]: https://eprint.iacr.org/2015/189.pdf