### PR TITLE
js: Refactor to expose as much high-level functionality as possible

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -449,7 +449,7 @@ understand the security concerns, and would like to use it anyway, create a
 `PolyfillCryptoProvider` instance and pass it into a constructor:
 
 ```typescript
-const key = miscreant.AEAD.importKey(keyData, "AES-PMAC-SIV", new PolyfillCryptoProvider());
+const key = miscreant.AEAD.importKey(keyData, "AES-PMAC-SIV", new miscreant.PolyfillCryptoProvider());
 ```
 
 ## Code of Conduct

--- a/js/src/aead.ts
+++ b/js/src/aead.ts
@@ -1,8 +1,7 @@
 import { IAEADLike, ICryptoProvider, ISIVLike } from "./interfaces";
 
+import { WebCryptoProvider } from "./providers/webcrypto";
 import { SIV } from "./siv";
-
-import WebCryptoProvider from "./providers/webcrypto";
 
 /** AEAD interface provider for ISIVLike types */
 export class AEAD implements IAEADLike {

--- a/js/src/exceptions/integrity_error.ts
+++ b/js/src/exceptions/integrity_error.ts
@@ -1,5 +1,5 @@
 /** Thrown when ciphertext fails to verify as authentic */
-export default class IntegrityError extends Error {
+export class IntegrityError extends Error {
   constructor(m: string) {
     super(m);
     Object.setPrototypeOf(this, IntegrityError.prototype);

--- a/js/src/exceptions/not_implemented_error.ts
+++ b/js/src/exceptions/not_implemented_error.ts
@@ -1,5 +1,5 @@
 /** Thrown when we attempt to use an unsupported crypto algorithm via WebCrypto */
-export default class NotImplementedError extends Error {
+export class NotImplementedError extends Error {
   constructor(m: string) {
     super(m);
     Object.setPrototypeOf(this, NotImplementedError.prototype);

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,4 +1,17 @@
+export * from "./interfaces";
+
+/** Exceptions */
+export { IntegrityError } from "./exceptions/integrity_error";
+export { NotImplementedError } from "./exceptions/not_implemented_error";
+
+/** Symmetric encryption APIs */
 export { AEAD } from "./aead";
 export { SIV } from "./siv";
 
-export * from "./interfaces";
+/** MAC functions */
+export { CMAC } from "./mac/cmac";
+export { PMAC } from "./mac/pmac";
+
+/** Crypto providers */
+export { PolyfillCryptoProvider } from "./providers/polyfill";
+export { WebCryptoProvider } from "./providers/webcrypto";

--- a/js/src/mac/cmac.ts
+++ b/js/src/mac/cmac.ts
@@ -8,7 +8,7 @@ import { xor } from "../internals/xor";
 /**
  * The AES-CMAC message authentication code
  */
-export default class CMAC implements IMACLike {
+export class CMAC implements IMACLike {
   /** Create a new CMAC instance from the given key */
   public static async importKey(provider: ICryptoProvider, keyData: Uint8Array): Promise<CMAC> {
     const cipher = await provider.importBlockCipherKey(keyData);

--- a/js/src/mac/pmac.ts
+++ b/js/src/mac/pmac.ts
@@ -17,7 +17,7 @@ const PRECOMPUTED_BLOCKS: number = 31;
  * Uses a non-constant-time (lookup table-based) AES polyfill.
  * See polyfill/aes.ts for more information on the security impact.
  */
-export default class PMAC implements IMACLike {
+export class PMAC implements IMACLike {
   /** Create a new CMAC instance from the given key */
   public static async importKey(provider: ICryptoProvider, keyData: Uint8Array): Promise<PMAC> {
     const cipher = await provider.importBlockCipherKey(keyData);

--- a/js/src/providers/polyfill.ts
+++ b/js/src/providers/polyfill.ts
@@ -7,7 +7,7 @@ import PolyfillAesCtr from "./polyfill/aes_ctr";
  *
  * WARNING: Not constant time! May leak keys or have other security issues.
  */
-export default class PolyfillCryptoProvider implements ICryptoProvider {
+export class PolyfillCryptoProvider implements ICryptoProvider {
   constructor() {
     // This class doesn't do anything, it just signals that polyfill impls should be used
   }

--- a/js/src/providers/webcrypto.ts
+++ b/js/src/providers/webcrypto.ts
@@ -1,10 +1,10 @@
-import NotImplementedError from "../exceptions/not_implemented_error";
+import { NotImplementedError } from "../exceptions/not_implemented_error";
 import { IBlockCipher, ICryptoProvider, ICTRLike } from "../interfaces";
 import WebCryptoAes from "./webcrypto/aes";
 import WebCryptoAesCtr from "./webcrypto/aes_ctr";
 
 /** Placeholder backend for using pure JavaScript crypto implementations */
-export default class WebCryptoProvider implements ICryptoProvider {
+export class WebCryptoProvider implements ICryptoProvider {
   constructor(
     private crypto: Crypto = window.crypto,
   ) {

--- a/js/src/siv.ts
+++ b/js/src/siv.ts
@@ -5,15 +5,15 @@ import { equal } from "./internals/constant-time";
 import { wipe } from "./internals/wipe";
 import { xor } from "./internals/xor";
 
-import IntegrityError from "./exceptions/integrity_error";
-import NotImplementedError from "./exceptions/not_implemented_error";
+import { IntegrityError } from "./exceptions/integrity_error";
+import { NotImplementedError } from "./exceptions/not_implemented_error";
 import { ICryptoProvider, ICTRLike, IMACLike, ISIVLike } from "./interfaces";
 import Block from "./internals/block";
 
-import CMAC from "./mac/cmac";
-import PMAC from "./mac/pmac";
+import { CMAC } from "./mac/cmac";
+import { PMAC } from "./mac/pmac";
 
-import WebCryptoProvider from "./providers/webcrypto";
+import { WebCryptoProvider } from "./providers/webcrypto";
 
 /** Maximum number of associated data items */
 export const MAX_ASSOCIATED_DATA = 126;

--- a/js/test/aes_cmac.spec.ts
+++ b/js/test/aes_cmac.spec.ts
@@ -6,9 +6,7 @@ import { expect } from "chai";
 import { AesCmacExample } from "./support/test_vectors";
 
 import WebCrypto = require("node-webcrypto-ossl");
-import PolyfillCryptoProvider from "../src/providers/polyfill";
-import WebCryptoProvider from "../src/providers/webcrypto";
-import CMAC from "../src/mac/cmac";
+import * as miscreant from "../src/index";
 
 @suite class PolyfillAesCmacSpec {
   static vectors: AesCmacExample[];
@@ -18,10 +16,10 @@ import CMAC from "../src/mac/cmac";
   }
 
   @test async "passes the AES-CMAC test vectors"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of PolyfillAesCmacSpec.vectors) {
-      const mac = await CMAC.importKey(polyfillProvider, v.key);
+      const mac = await miscreant.CMAC.importKey(polyfillProvider, v.key);
       await mac.update(v.message);
       expect(await mac.finish()).to.eql(v.tag);
     }
@@ -36,10 +34,10 @@ import CMAC from "../src/mac/cmac";
   }
 
   @test async "passes the AES-CMAC test vectors"() {
-    const webCryptoProvider = new WebCryptoProvider(new WebCrypto());
+    const webCryptoProvider = new miscreant.WebCryptoProvider(new WebCrypto());
 
     for (let v of PolyfillAesCmacSpec.vectors) {
-      const mac = await CMAC.importKey(webCryptoProvider, v.key);
+      const mac = await miscreant.CMAC.importKey(webCryptoProvider, v.key);
       await mac.update(v.message);
       expect(await mac.finish()).to.eql(v.tag);
     }

--- a/js/test/aes_pmac.spec.ts
+++ b/js/test/aes_pmac.spec.ts
@@ -6,9 +6,8 @@ import { expect } from "chai";
 import { AesPmacExample } from "./support/test_vectors";
 
 import WebCrypto = require("node-webcrypto-ossl");
-import PolyfillCryptoProvider from "../src/providers/polyfill";
-import WebCryptoProvider from "../src/providers/webcrypto";
-import PMAC from "../src/mac/pmac";
+import * as miscreant from "../src/index";
+
 
 @suite class PolyfillAesPmacSpec {
   static vectors: AesPmacExample[];
@@ -18,10 +17,10 @@ import PMAC from "../src/mac/pmac";
   }
 
   @test async "passes the AES-PMAC test vectors"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of PolyfillAesPmacSpec.vectors) {
-      const mac = await PMAC.importKey(polyfillProvider, v.key);
+      const mac = await miscreant.PMAC.importKey(polyfillProvider, v.key);
       await mac.update(v.message);
       expect(v.tag).to.eql(await mac.finish());
     }
@@ -36,10 +35,10 @@ import PMAC from "../src/mac/pmac";
   }
 
   @test async "passes the AES-PMAC test vectors"() {
-    const webCryptoProvider = new WebCryptoProvider(new WebCrypto());
+    const webCryptoProvider = new miscreant.WebCryptoProvider(new WebCrypto());
 
     for (let v of PolyfillAesPmacSpec.vectors) {
-      const mac = await PMAC.importKey(webCryptoProvider, v.key);
+      const mac = await miscreant.PMAC.importKey(webCryptoProvider, v.key);
       await mac.update(v.message);
       expect(v.tag).to.eql(await mac.finish());
     }

--- a/js/test/aes_pmac_siv.spec.ts
+++ b/js/test/aes_pmac_siv.spec.ts
@@ -7,11 +7,7 @@ import * as chaiAsPromised from "chai-as-promised";
 import { AesPmacSivExample } from "./support/test_vectors";
 
 import WebCrypto = require("node-webcrypto-ossl");
-import PolyfillCryptoProvider from "../src/providers/polyfill";
-import WebCryptoProvider from "../src/providers/webcrypto";
-
 import * as miscreant from "../src/index";
-import IntegrityError from "../src/exceptions/integrity_error";
 
 let expect = chai.expect;
 chai.use(chaiAsPromised);
@@ -24,7 +20,7 @@ chai.use(chaiAsPromised);
   }
 
   @test async "should correctly seal and open with polyfill cipher implementations"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AesPmacSivSpec.vectors) {
       const siv = await miscreant.SIV.importKey(v.key, "AES-PMAC-SIV", polyfillProvider);
@@ -39,7 +35,7 @@ chai.use(chaiAsPromised);
   }
 
   @test async "should correctly seal and open with WebCrypto cipher implementations"() {
-    const webCryptoProvider = new WebCryptoProvider(new WebCrypto());
+    const webCryptoProvider = new miscreant.WebCryptoProvider(new WebCrypto());
 
     for (let v of AesPmacSivSpec.vectors) {
       const siv = await miscreant.SIV.importKey(v.key, "AES-PMAC-SIV", webCryptoProvider);
@@ -54,19 +50,19 @@ chai.use(chaiAsPromised);
   }
 
   @test async "should not open with incorrect associated data"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AesPmacSivSpec.vectors) {
       const badAd = v.ad;
       badAd.push(new Uint8Array(1));
 
       const siv = await miscreant.SIV.importKey(v.key, "AES-PMAC-SIV", polyfillProvider);
-      await expect(siv.open(v.ciphertext, badAd)).to.be.rejectedWith(IntegrityError);
+      await expect(siv.open(v.ciphertext, badAd)).to.be.rejectedWith(miscreant.IntegrityError);
     }
   }
 
   @test async "should not open with incorrect ciphertext"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AesPmacSivSpec.vectors) {
       const badOutput = v.ciphertext;
@@ -75,7 +71,7 @@ chai.use(chaiAsPromised);
       badOutput[3] ^= badOutput[8];
 
       const siv = await miscreant.SIV.importKey(v.key, "AES-PMAC-SIV", polyfillProvider);
-      await expect(siv.open(badOutput, v.ad)).to.be.rejectedWith(IntegrityError);
+      await expect(siv.open(badOutput, v.ad)).to.be.rejectedWith(miscreant.IntegrityError);
     }
   }
 }

--- a/js/test/aes_siv.spec.ts
+++ b/js/test/aes_siv.spec.ts
@@ -7,11 +7,7 @@ import * as chaiAsPromised from "chai-as-promised";
 import { AesSivExample } from "./support/test_vectors";
 
 import WebCrypto = require("node-webcrypto-ossl");
-import PolyfillCryptoProvider from "../src/providers/polyfill";
-import WebCryptoProvider from "../src/providers/webcrypto";
-
 import * as miscreant from "../src/index";
-import IntegrityError from "../src/exceptions/integrity_error";
 
 let expect = chai.expect;
 chai.use(chaiAsPromised);
@@ -24,7 +20,7 @@ chai.use(chaiAsPromised);
   }
 
   @test async "should correctly seal and open with polyfill cipher implementations"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AesSivSpec.vectors) {
       const siv = await miscreant.SIV.importKey(v.key, "AES-SIV", polyfillProvider);
@@ -39,7 +35,7 @@ chai.use(chaiAsPromised);
   }
 
   @test async "should correctly seal and open with WebCrypto cipher implementations"() {
-    const webCryptoProvider = new WebCryptoProvider(new WebCrypto());
+    const webCryptoProvider = new miscreant.WebCryptoProvider(new WebCrypto());
 
     for (let v of AesSivSpec.vectors) {
       const siv = await miscreant.SIV.importKey(v.key, "AES-SIV", webCryptoProvider);
@@ -54,7 +50,7 @@ chai.use(chaiAsPromised);
   }
 
   @test async "should correctly seal and open different plaintext under the same key"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     const key = byteSeq(64);
     const ad1 = [byteSeq(32), byteSeq(10)];
@@ -79,7 +75,7 @@ chai.use(chaiAsPromised);
   }
 
   @test async "should not open with incorrect key"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AesSivSpec.vectors) {
       const badKey = v.key;
@@ -88,24 +84,24 @@ chai.use(chaiAsPromised);
       badKey[3] ^= badKey[8];
 
       const siv = await miscreant.SIV.importKey(badKey, "AES-SIV", polyfillProvider);
-      await expect(siv.open(v.ciphertext, v.ad)).to.be.rejectedWith(IntegrityError);
+      await expect(siv.open(v.ciphertext, v.ad)).to.be.rejectedWith(miscreant.IntegrityError);
     }
   }
 
   @test async "should not open with incorrect associated data"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AesSivSpec.vectors) {
       const badAd = v.ad;
       badAd.push(new Uint8Array(1));
 
       const siv = await miscreant.SIV.importKey(v.key, "AES-SIV", polyfillProvider);
-      await expect(siv.open(v.ciphertext, badAd)).to.be.rejectedWith(IntegrityError);
+      await expect(siv.open(v.ciphertext, badAd)).to.be.rejectedWith(miscreant.IntegrityError);
     }
   }
 
   @test async "should not open with incorrect ciphertext"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AesSivSpec.vectors) {
       const badOutput = v.ciphertext;
@@ -114,7 +110,7 @@ chai.use(chaiAsPromised);
       badOutput[3] ^= badOutput[8];
 
       const siv = await miscreant.SIV.importKey(v.key, "AES-SIV", polyfillProvider);
-      await expect(siv.open(badOutput, v.ad)).to.be.rejectedWith(IntegrityError);
+      await expect(siv.open(badOutput, v.ad)).to.be.rejectedWith(miscreant.IntegrityError);
     }
   }
 }

--- a/js/test/aes_siv_aead.spec.ts
+++ b/js/test/aes_siv_aead.spec.ts
@@ -4,11 +4,7 @@ import * as chaiAsPromised from "chai-as-promised";
 import { AEADExample } from "./support/test_vectors";
 
 import WebCrypto = require("node-webcrypto-ossl");
-import PolyfillCryptoProvider from "../src/providers/polyfill";
-import WebCryptoProvider from "../src/providers/webcrypto";
-
-import * as miscreant from "../src";
-import IntegrityError from "../src/exceptions/integrity_error";
+import * as miscreant from "../src/index";
 
 let expect = chai.expect;
 chai.use(chaiAsPromised);
@@ -21,7 +17,7 @@ chai.use(chaiAsPromised);
   }
 
   @test async "should correctly seal and open with polyfill cipher implementations"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AEADSpec.vectors) {
       const aead = await miscreant.AEAD.importKey(v.key, v.alg, polyfillProvider);
@@ -36,7 +32,7 @@ chai.use(chaiAsPromised);
   }
 
   @test async "should correctly seal and open with WebCrypto cipher implementations"() {
-    const webCryptoProvider = new WebCryptoProvider(new WebCrypto());
+    const webCryptoProvider = new miscreant.WebCryptoProvider(new WebCrypto());
 
     for (let v of AEADSpec.vectors) {
       const aead = await miscreant.AEAD.importKey(v.key, v.alg, webCryptoProvider);
@@ -51,7 +47,7 @@ chai.use(chaiAsPromised);
   }
 
   @test async "should not open with incorrect key"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AEADSpec.vectors) {
       const badKey = v.key;
@@ -60,23 +56,23 @@ chai.use(chaiAsPromised);
       badKey[3] ^= badKey[8];
 
       const siv = await miscreant.AEAD.importKey(badKey, "AES-SIV", polyfillProvider);
-      await expect(siv.open(v.ciphertext, v.nonce, v.ad)).to.be.rejectedWith(IntegrityError);
+      await expect(siv.open(v.ciphertext, v.nonce, v.ad)).to.be.rejectedWith(miscreant.IntegrityError);
     }
   }
 
   @test async "should not open with incorrect associated data"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AEADSpec.vectors) {
       const badAd = new Uint8Array(1);
 
       const siv = await miscreant.AEAD.importKey(v.key, "AES-SIV", polyfillProvider);
-      await expect(siv.open(v.ciphertext, v.nonce, badAd)).to.be.rejectedWith(IntegrityError);
+      await expect(siv.open(v.ciphertext, v.nonce, badAd)).to.be.rejectedWith(miscreant.IntegrityError);
     }
   }
 
   @test async "should not open with incorrect ciphertext"() {
-    const polyfillProvider = new PolyfillCryptoProvider();
+    const polyfillProvider = new miscreant.PolyfillCryptoProvider();
 
     for (let v of AEADSpec.vectors) {
       const badOutput = v.ciphertext;
@@ -85,7 +81,7 @@ chai.use(chaiAsPromised);
       badOutput[3] ^= badOutput[8];
 
       const siv = await miscreant.AEAD.importKey(v.key, "AES-SIV", polyfillProvider);
-      await expect(siv.open(badOutput, v.nonce, v.ad)).to.be.rejectedWith(IntegrityError);
+      await expect(siv.open(badOutput, v.nonce, v.ad)).to.be.rejectedWith(miscreant.IntegrityError);
     }
   }
 }


### PR DESCRIPTION
Ditches default classes anywhere in the public API

Exposes:
- CMAC
- PMAC
- WebCrypto and Polyfill provider classes
- Exception classes