### PR TITLE
rust: Add C ABI (closes #107)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,8 @@ matrix:
   - language: rust
     rust: nightly
     before_script: cd rust
-    script: cargo build --no-default-features
+    script:
+    - cargo build --no-default-features --features=staticlib --release
+    - cd tests/ffi
+    - make
+    - ./ffi_test

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -26,11 +26,16 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "clear_on_drop"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -140,7 +145,7 @@ dependencies = [
  "aesni 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "block-cipher-trait 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clear_on_drop 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -148,7 +153,7 @@ dependencies = [
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pmac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -228,18 +233,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_json"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -262,7 +267,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum block-cipher-trait 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6136d803280ae3532efa36114335255ea94f3d75d735ddedd66b0d7cd30bad3"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
-"checksum clear_on_drop 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "27fc408dd80e7fe9d5b1c8cee6c2add84bea237d8dee70880a76ae7957f6d3a6"
+"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
+"checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cmac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f175b5f76aa82ebe4c7e85ef95b23e9293c5618db28461cb10ee929e0f6e2f"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
@@ -287,8 +293,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rayon-core 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e64b609139d83da75902f88fd6c01820046840a18471e4dfcd5ac7c0f46bea53"
 "checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7c37d7f192f00041e8a613e936717923a71bc0c9051fc4425a49b104140f05"
-"checksum serde_json 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ea28ea0cca944668919bec6af209864a8dfe769fd2b0b723f36b22e20c1bf69f"
+"checksum serde 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "386122ba68c214599c44587e0c0b411e8d90894503a95425b4f9508e4317901f"
+"checksum serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7cf5b0b5b4bd22eeecb7e01ac2e1225c7ef5e4272b79ee28a8392a8c8489c839"
 "checksum subtle 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7a6bab57c3efd01ebd3d750f4244ae0af4cdd1fc505a7904a41603192b803c5"
 "checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,9 @@ readme      = "README.md"
 categories  = ["cryptography", "no-std"]
 keywords    = ["cryptography", "encryption", "security", "streaming"]
 
+[lib]
+crate-type = ["rlib", "staticlib"]
+
 [dependencies]
 aesni = "0.2"
 crypto-mac = "0.6"
@@ -30,7 +33,17 @@ serde_json = "1"
 [features]
 bench = ["ring"]
 default = ["std"]
+staticlib = []
 std = []
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = false
+debug-assertions = false
+codegen-units = 1
+panic = "abort"
 
 [profile.bench]
 opt-level = 3

--- a/rust/include/miscreant.h
+++ b/rust/include/miscreant.h
@@ -1,0 +1,129 @@
+/**
+ * Miscreant: Advanced symmetric encryption library which provides the AES-SIV,
+ * AES-PMAC-SIV, and STREAM constructions.
+ *
+ * This header file describes the C ABI exposed from the Rust implementation.
+ * C99 support is assumed.
+ */
+
+#include <stdint.h>
+
+/********************
+ * AES-128-SIV AEAD *
+ ********************/
+
+// AES-128-SIV key size
+extern uint32_t crypto_aead_aes128siv_KEYBYTES;
+
+// AES-128-SIV authenticator tag size
+extern uint32_t crypto_aead_aes128siv_ABYTES;
+
+// AES-128-SIV authenticated encryption
+// Requires *ctlen_p == msglen + 16
+int crypto_aead_aes128siv_encrypt(
+    uint8_t *ct, uint64_t *ctlen_p,
+    const uint8_t *msg, uint64_t msglen,
+    const uint8_t *nonce, uint64_t noncelen,
+    const uint8_t *ad, uint64_t adlen,
+    const uint8_t *key
+);
+
+// AES-128-SIV authenticated decryption
+// Requires *msglen_p == ctlen
+int crypto_aead_aes128siv_decrypt(
+    uint8_t *msg, uint64_t *ctlen_p,
+    const uint8_t *ct, uint64_t ctlen,
+    const uint8_t *nonce, uint64_t noncelen,
+    const uint8_t *ad, uint64_t adlen,
+    const uint8_t *key
+);
+
+/********************
+ * AES-256-SIV AEAD *
+ ********************/
+
+// AES-256-SIV key size
+extern uint32_t crypto_aead_aes256siv_KEYBYTES;
+
+// AES-256-SIV authenticator tag size
+extern uint32_t crypto_aead_aes256siv_ABYTES;
+
+// AES-256-SIV authenticated encryption
+// Requires *ctlen_p == msglen + 16
+int crypto_aead_aes256siv_encrypt(
+    uint8_t *ct, uint64_t *ctlen_p,
+    const uint8_t *msg, uint64_t msglen,
+    const uint8_t *nonce, uint64_t noncelen,
+    const uint8_t *ad, uint64_t adlen,
+    const uint8_t *key
+);
+
+// AES-256-SIV authenticated decryption
+// Requires *msglen_p == ctlen
+int crypto_aead_aes256siv_decrypt(
+    uint8_t *msg, uint64_t *ctlen_p,
+    const uint8_t *ct, uint64_t ctlen,
+    const uint8_t *nonce, uint64_t noncelen,
+    const uint8_t *ad, uint64_t adlen,
+    const uint8_t *key
+);
+
+/*************************
+ * AES-128-PMAC-SIV AEAD *
+ *************************/
+
+// AES-128-PMAC-SIV key size
+extern uint32_t crypto_aead_aes128pmacsiv_KEYBYTES;
+
+// AES-128-PMAC-SIV authenticator tag size
+extern uint32_t crypto_aead_aes128pmacsiv_ABYTES;
+
+// AES-128-SIV authenticated encryption
+// Requires *ctlen_p == msglen + 16
+int crypto_aead_aes128pmacsiv_encrypt(
+    uint8_t *ct, uint64_t *ctlen_p,
+    const uint8_t *msg, uint64_t msglen,
+    const uint8_t *nonce, uint64_t noncelen,
+    const uint8_t *ad, uint64_t adlen,
+    const uint8_t *key
+);
+
+// AES-128-SIV authenticated decryption
+// Requires *msglen_p == ctlen
+int crypto_aead_aes128pmacsiv_decrypt(
+    uint8_t *msg, uint64_t *ctlen_p,
+    const uint8_t *ct, uint64_t ctlen,
+    const uint8_t *nonce, uint64_t noncelen,
+    const uint8_t *ad, uint64_t adlen,
+    const uint8_t *key
+);
+
+/*************************
+ * AES-256-PMAC-SIV AEAD *
+ *************************/
+
+// AES-256-PMAC-SIV key size
+extern uint32_t crypto_aead_aes256pmacsiv_KEYBYTES;
+
+// AES-256-PMAC-SIV authenticator tag size
+extern uint32_t crypto_aead_aes256pmacsiv_ABYTES;
+
+// AES-256-PMAC-SIV authenticated encryption
+// Requires *ctlen_p == msglen + 16
+int crypto_aead_aes256pmacsiv_encrypt(
+    uint8_t *ct, uint64_t *ctlen_p,
+    const uint8_t *msg, uint64_t msglen,
+    const uint8_t *nonce, uint64_t noncelen,
+    const uint8_t *ad, uint64_t adlen,
+    const uint8_t *key
+);
+
+// AES-256-PMAC-SIV authenticated decryption
+// Requires *msglen_p == ctlen
+int crypto_aead_aes256pmacsiv_decrypt(
+    uint8_t *msg, uint64_t *ctlen_p,
+    const uint8_t *ct, uint64_t ctlen,
+    const uint8_t *nonce, uint64_t noncelen,
+    const uint8_t *ad, uint64_t adlen,
+    const uint8_t *key
+);

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1,0 +1,349 @@
+//! `ffi.rs`: Foreign Function Interface providing C ABI
+
+// This is the only code in Miscreant allowed to be unsafe
+#![allow(unsafe_code)]
+#![allow(non_upper_case_globals)]
+
+use aead;
+use core::{ptr, slice};
+use generic_array::typenum::Unsigned;
+
+//
+// AES-128-SIV AEAD
+//
+
+/// AES-128-SIV AEAD: authenticated encryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes128siv_encrypt(
+    ct: *mut u8,
+    ctlen_p: *mut u64,
+    msg: *const u8,
+    msglen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_encrypt::<aead::Aes128Siv>(
+        ct,
+        ctlen_p,
+        msg,
+        msglen,
+        nonce,
+        noncelen,
+        ad,
+        adlen,
+        key,
+    )
+}
+
+/// AES-128-SIV AEAD: authenticated decryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes128siv_decrypt(
+    msg: *mut u8,
+    msglen_p: *mut u64,
+    ct: *const u8,
+    ctlen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_decrypt::<aead::Aes128Siv>(
+        msg,
+        msglen_p,
+        ct,
+        ctlen,
+        nonce,
+        noncelen,
+        ad,
+        adlen,
+        key,
+    )
+}
+
+/// AES-128-SIV key size
+#[no_mangle]
+pub static crypto_aead_aes128siv_KEYBYTES: u32 = 32;
+
+/// AES-128-SIV authenticator tag size
+#[no_mangle]
+pub static crypto_aead_aes128siv_ABYTES: u32 = 16;
+
+//
+// AES-256-SIV AEAD
+//
+
+/// AES-256-SIV AEAD: authenticated encryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes256siv_encrypt(
+    ct: *mut u8,
+    ctlen_p: *mut u64,
+    msg: *const u8,
+    msglen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_encrypt::<aead::Aes256Siv>(
+        ct,
+        ctlen_p,
+        msg,
+        msglen,
+        nonce,
+        noncelen,
+        ad,
+        adlen,
+        key,
+    )
+}
+
+/// AES-256-SIV AEAD: authenticated decryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes256siv_decrypt(
+    msg: *mut u8,
+    msglen_p: *mut u64,
+    ct: *const u8,
+    ctlen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_decrypt::<aead::Aes256Siv>(
+        msg,
+        msglen_p,
+        ct,
+        ctlen,
+        nonce,
+        noncelen,
+        ad,
+        adlen,
+        key,
+    )
+}
+
+/// AES-128-SIV key size
+#[no_mangle]
+pub static crypto_aead_aes256siv_KEYBYTES: u32 = 64;
+
+/// AES-128-SIV authenticator tag size
+#[no_mangle]
+pub static crypto_aead_aes256siv_ABYTES: u32 = 16;
+
+//
+// AES-128-PMAC-SIV AEAD
+//
+
+/// AES-128-PMAC-SIV AEAD: authenticated encryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes128pmacsiv_encrypt(
+    ct: *mut u8,
+    ctlen_p: *mut u64,
+    msg: *const u8,
+    msglen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_encrypt::<aead::Aes128PmacSiv>(
+        ct,
+        ctlen_p,
+        msg,
+        msglen,
+        nonce,
+        noncelen,
+        ad,
+        adlen,
+        key,
+    )
+}
+
+/// AES-128-PMAC-SIV AEAD: authenticated decryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes128pmacsiv_decrypt(
+    msg: *mut u8,
+    msglen_p: *mut u64,
+    ct: *const u8,
+    ctlen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_decrypt::<aead::Aes128PmacSiv>(
+        msg,
+        msglen_p,
+        ct,
+        ctlen,
+        nonce,
+        noncelen,
+        ad,
+        adlen,
+        key,
+    )
+}
+
+/// AES-128-PMAC-SIV key size
+#[no_mangle]
+pub static crypto_aead_aes128pmacsiv_KEYBYTES: u32 = 32;
+
+/// AES-128-PMAC-SIV authenticator tag size
+#[no_mangle]
+pub static crypto_aead_aes128pmacsiv_ABYTES: u32 = 16;
+
+//
+// AES-256-PMAC-SIV AEAD
+//
+
+/// AES-256-PMAC-SIV AEAD: authenticated encryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes256pmacsiv_encrypt(
+    ct: *mut u8,
+    ctlen_p: *mut u64,
+    msg: *const u8,
+    msglen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_encrypt::<aead::Aes256PmacSiv>(
+        ct,
+        ctlen_p,
+        msg,
+        msglen,
+        nonce,
+        noncelen,
+        ad,
+        adlen,
+        key,
+    )
+}
+
+/// AES-256-PMAC-SIV AEAD: authenticated decryption
+#[no_mangle]
+pub unsafe extern "C" fn crypto_aead_aes256pmacsiv_decrypt(
+    msg: *mut u8,
+    msglen_p: *mut u64,
+    ct: *const u8,
+    ctlen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    aead_decrypt::<aead::Aes256PmacSiv>(
+        msg,
+        msglen_p,
+        ct,
+        ctlen,
+        nonce,
+        noncelen,
+        ad,
+        adlen,
+        key,
+    )
+}
+
+/// AES-128-SIV key size
+#[no_mangle]
+pub static crypto_aead_aes256pmacsiv_KEYBYTES: u32 = 64;
+
+/// AES-128-SIV authenticator tag size
+#[no_mangle]
+pub static crypto_aead_aes256pmacsiv_ABYTES: u32 = 16;
+
+//
+// Generic AEAD encrypt/decrypt
+//
+
+/// Generic C-like interface to AEAD encryption
+unsafe fn aead_encrypt<A: aead::Algorithm>(
+    ct: *mut u8,
+    ctlen_p: *mut u64,
+    msg: *const u8,
+    msglen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    let taglen = A::TagSize::to_usize();
+
+    if *ctlen_p < msglen.checked_add(taglen as u64).expect("overflow") {
+        return -1;
+    }
+
+    *ctlen_p = msglen.checked_add(taglen as u64).expect("overflow");
+    ptr::copy(msg, ct.offset(taglen as isize), msglen as usize);
+
+    let key_slice = slice::from_raw_parts(key, A::KeySize::to_usize());
+    let ct_slice = slice::from_raw_parts_mut(ct, *ctlen_p as usize);
+    let nonce_slice = slice::from_raw_parts(nonce, noncelen as usize);
+    let ad_slice = slice::from_raw_parts(ad, adlen as usize);
+
+    A::new(key_slice).seal_in_place(nonce_slice, ad_slice, ct_slice);
+
+    return 0;
+}
+
+/// Generic C-like interface to AEAD decryption
+unsafe fn aead_decrypt<A: aead::Algorithm>(
+    msg: *mut u8,
+    msglen_p: *mut u64,
+    ct: *const u8,
+    ctlen: u64,
+    nonce: *const u8,
+    noncelen: u64,
+    ad: *const u8,
+    adlen: u64,
+    key: *const u8,
+) -> i32 {
+    let taglen = A::TagSize::to_usize();
+
+    if ctlen < taglen as u64 {
+        return -1;
+    }
+
+    // TODO: support decrypting messages into buffers smaller than the ciphertext
+    if *msglen_p < ctlen {
+        return -1;
+    }
+
+    *msglen_p = ctlen.checked_sub(taglen as u64).expect("underflow");
+    ptr::copy(ct, msg, ctlen as usize);
+
+    let key_slice = slice::from_raw_parts(key, A::KeySize::to_usize());
+    let msg_slice = slice::from_raw_parts_mut(msg, ctlen as usize);
+    let ad_slice = slice::from_raw_parts(ad, adlen as usize);
+    let nonce_slice = slice::from_raw_parts(nonce, noncelen as usize);
+
+    if A::new(key_slice)
+        .open_in_place(nonce_slice, ad_slice, msg_slice)
+        .is_err()
+    {
+        return -1;
+    }
+
+    // Move the message to the beginning of the buffer
+    ptr::copy(msg.offset(taglen as isize), msg, *msglen_p as usize);
+
+    // Zero out the end of the buffer
+    for c in msg_slice[*msglen_p as usize..].iter_mut() {
+        *c = 0;
+    }
+
+    return 0;
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "bench", feature(test))]
+#![cfg_attr(feature = "staticlib", feature(lang_items))]
 
 extern crate aesni;
 extern crate byteorder;
@@ -30,9 +31,18 @@ extern crate test;
 pub mod aead;
 mod ctr;
 pub mod error;
+pub mod ffi;
 pub mod siv;
 mod s2v;
 pub mod stream;
 
 #[cfg(feature = "bench")]
 mod bench;
+
+// no_std boilerplate for building a static library
+#[cfg(feature = "staticlib")]
+#[allow(unsafe_code)]
+#[lang = "panic_fmt"]
+extern "C" fn panic_fmt(_args: ::core::fmt::Arguments, _file: &'static str, _line: u32) -> ! {
+    loop {}
+}

--- a/rust/tests/ffi/.gitignore
+++ b/rust/tests/ffi/.gitignore
@@ -1,0 +1,2 @@
+*.o
+ffi_test

--- a/rust/tests/ffi/Makefile
+++ b/rust/tests/ffi/Makefile
@@ -1,0 +1,9 @@
+CFLAGS=-I../../include -Wall -O3 -pedantic -std=c99
+
+all: ffi_test
+
+clean:
+	rm -f *.o ffi_test
+
+ffi_test: ffi_test.o
+	$(CC) $(LDFLAGS) -lc -o ffi_test ffi_test.o ../../target/release/libmiscreant.a

--- a/rust/tests/ffi/ffi_test.c
+++ b/rust/tests/ffi/ffi_test.c
@@ -1,0 +1,188 @@
+/**
+ * Test for the Miscreant C ABI
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "miscreant.h"
+
+void test_aead_aes128siv() {
+    // AES-SIV Nonce-based Authenticated Encryption Example #1
+    const uint8_t key[] = "\x7F\x7E\x7D\x7C\x7B\x7A\x79\x78\x77\x76\x75\x74\x73\x72\x71\x70\x40\x41\x42\x43\x44\x45\x46\x47\x48\x49\x4A\x4B\x4C\x4D\x4E\x4F";
+    const uint8_t nonce[] = "\x09\xF9\x11\x02\x9D\x74\xE3\x5B\xD8\x41\x56\xC5\x63\x56\x88\xC0";
+    const uint8_t ad[] = "\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xAA\xBB\xCC\xDD\xEE\xFF\xDE\xAD\xDA\xDA\xDE\xAD\xDA\xDA\xFF\xEE\xDD\xCC\xBB\xAA\x99\x88\x77\x66\x55\x44\x33\x22\x11\x00";
+    const uint8_t pt[] = "\x74\x68\x69\x73\x20\x69\x73\x20\x73\x6F\x6D\x65\x20\x70\x6C\x61\x69\x6E\x74\x65\x78\x74\x20\x74\x6F\x20\x65\x6E\x63\x72\x79\x70\x74\x20\x75\x73\x69\x6E\x67\x20\x53\x49\x56\x2D\x41\x45\x53";
+    const uint8_t ct[] = "\x85\x82\x5E\x22\xE9\x0C\xF2\xDD\xDA\x2C\x54\x8D\xC7\xC1\xB6\x31\x0D\xCD\xAC\xA0\xCE\xBF\x9D\xC6\xCB\x90\x58\x3F\x5B\xF1\x50\x6E\x02\xCD\x48\x83\x2B\x00\xE4\xE5\x98\xB2\xB2\x2A\x53\xE6\x19\x9D\x4D\xF0\xC1\x66\x6A\x35\xA0\x43\x3B\x25\x0D\xC1\x34\xD7\x76";
+
+    uint8_t buf[sizeof(ct)] = {0};
+    uint64_t buflen = sizeof(buf) - 1;
+
+    assert(sizeof(pt) + crypto_aead_aes128siv_ABYTES == sizeof(buf));
+
+    // Test encryption
+    if(crypto_aead_aes128siv_encrypt(
+        buf, &buflen,
+        pt, sizeof(pt) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes128siv AEAD: encryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, ct, sizeof(ct) - 1) == 0);
+
+    // Test decryption
+    if(crypto_aead_aes128siv_decrypt(
+        buf, &buflen,
+        ct, sizeof(ct) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes128siv AEAD: decryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, pt, sizeof(pt) - 1) == 0);
+}
+
+void test_aead_aes256siv() {
+    // AES-SIV Nonce-based Authenticated Encryption Example #2
+    const uint8_t key[] = "\xFF\xFE\xFD\xFC\xFB\xFA\xF9\xF8\xF7\xF6\xF5\xF4\xF3\xF2\xF1\xF0\x6F\x6E\x6D\x6C\x6B\x6A\x69\x68\x67\x66\x65\x64\x63\x62\x61\x60\xF0\xF1\xF2\xF3\xF4\xF5\xF6\xF7\xF8\xF9\xFA\xFB\xFC\xFD\xFE\xFF\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F";
+    const uint8_t nonce[] = "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x20\x21\x22\x23\x24\x25\x26\x27";
+    const uint8_t ad[] = "";
+    const uint8_t pt[] = "\x11\x22\x33\x44\x55\x66\x77\x88\x99\xAA\xBB\xCC\xDD\xEE";
+    const uint8_t ct[] = "\xE6\x18\xD2\xD6\xA8\x6B\x50\xA8\xD7\xDF\x82\xAB\x34\xAA\x95\x0A\xB3\x19\xD7\xFC\x15\xF7\xCD\x1E\xA9\x9B\x1A\x03\x3F\x20";
+
+    uint8_t buf[sizeof(ct)] = {0};
+    uint64_t buflen = sizeof(buf) - 1;
+
+    assert(sizeof(pt) + crypto_aead_aes256siv_ABYTES == sizeof(buf));
+
+    // Test encryption
+    if(crypto_aead_aes256siv_encrypt(
+        buf, &buflen,
+        pt, sizeof(pt) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes256siv AEAD: encryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, ct, sizeof(ct) - 1) == 0);
+
+    // Test decryption
+    if(crypto_aead_aes256siv_decrypt(
+        buf, &buflen,
+        ct, sizeof(ct) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes256siv AEAD: decryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, pt, sizeof(pt) - 1) == 0);
+}
+
+void test_aead_aes128pmacsiv() {
+    // AES-PMAC-SIV Authenticted Encryption with Associated Data Example
+    const uint8_t key[] = "\x7F\x7E\x7D\x7C\x7B\x7A\x79\x78\x77\x76\x75\x74\x73\x72\x71\x70\x40\x41\x42\x43\x44\x45\x46\x47\x48\x49\x4A\x4B\x4C\x4D\x4E\x4F";
+    const uint8_t nonce[] = "\x09\xF9\x11\x02\x9D\x74\xE3\x5B\xD8\x41\x56\xC5\x63\x56\x88\xC0";
+    const uint8_t ad[] = "\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xAA\xBB\xCC\xDD\xEE\xFF\xDE\xAD\xDA\xDA\xDE\xAD\xDA\xDA\xFF\xEE\xDD\xCC\xBB\xAA\x99\x88\x77\x66\x55\x44\x33\x22\x11\x00";
+    const uint8_t pt[] = "\x74\x68\x69\x73\x20\x69\x73\x20\x73\x6F\x6D\x65\x20\x70\x6C\x61\x69\x6E\x74\x65\x78\x74\x20\x74\x6F\x20\x65\x6E\x63\x72\x79\x70\x74\x20\x75\x73\x69\x6E\x67\x20\x53\x49\x56\x2D\x41\x45\x53";
+    const uint8_t ct[] = "\x14\x63\xD1\x11\x9B\x2A\x27\x97\x24\x1B\xB1\x67\x46\x33\xDF\xF1\x3B\x9D\xE1\x1E\x5E\x2F\x52\x60\x48\xB3\x6C\x40\xC7\x72\x26\x67\xB2\x95\x70\x18\x02\x3B\xF0\xE5\x27\x92\xB7\x03\xA0\x1E\x88\xAA\xCD\x49\x89\x8C\xEC\xFC\xE9\x43\xD7\xF6\x1A\x23\x37\xA0\x97";
+
+    uint8_t buf[sizeof(ct)] = {0};
+    uint64_t buflen = sizeof(buf) - 1;
+
+    assert(sizeof(pt) + crypto_aead_aes128pmacsiv_ABYTES == sizeof(buf));
+
+    // Test encryption
+    if(crypto_aead_aes128pmacsiv_encrypt(
+        buf, &buflen,
+        pt, sizeof(pt) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes128pmacsiv AEAD: encryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, ct, sizeof(ct) - 1) == 0);
+
+    // Test decryption
+    if(crypto_aead_aes128pmacsiv_decrypt(
+        buf, &buflen,
+        ct, sizeof(ct) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes128pmacsiv AEAD: decryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, pt, sizeof(pt) - 1) == 0);
+}
+
+void test_aead_aes256pmacsiv() {
+    // AES-256-PMAC-SIV Authenticted Encryption with Associated Data Example #2
+    const uint8_t key[] = "\xFF\xFE\xFD\xFC\xFB\xFA\xF9\xF8\xF7\xF6\xF5\xF4\xF3\xF2\xF1\xF0\x6F\x6E\x6D\x6C\x6B\x6A\x69\x68\x67\x66\x65\x64\x63\x62\x61\x60\xF0\xF1\xF2\xF3\xF4\xF5\xF6\xF7\xF8\xF9\xFA\xFB\xFC\xFD\xFE\xFF\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F";
+    const uint8_t nonce[] = "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x20\x21\x22\x23\x24\x25\x26\x27";
+    const uint8_t ad[] = "";
+    const uint8_t pt[] = "\x11\x22\x33\x44\x55\x66\x77\x88\x99\xAA\xBB\xCC\xDD\xEE";
+    const uint8_t ct[] = "\x06\x23\xA7\x27\x5A\xFD\x50\x82\x03\x5E\x43\xB0\xDC\xAF\xE3\xA8\x91\xC2\xB8\xEE\xD2\xB1\xA0\x7F\x0D\xD2\x51\x80\xE0\x72";
+
+    uint8_t buf[sizeof(ct)] = {0};
+    uint64_t buflen = sizeof(buf) - 1;
+
+    assert(sizeof(pt) + crypto_aead_aes256pmacsiv_ABYTES == sizeof(buf));
+
+    // Test encryption
+    if(crypto_aead_aes256pmacsiv_encrypt(
+        buf, &buflen,
+        pt, sizeof(pt) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes256pmacsiv AEAD: encryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, ct, sizeof(ct) - 1) == 0);
+
+    // Test decryption
+    if(crypto_aead_aes256pmacsiv_decrypt(
+        buf, &buflen,
+        ct, sizeof(ct) - 1,
+        nonce, sizeof(nonce) - 1,
+        ad, sizeof(ad) - 1,
+        key
+     ) != 0) {
+        fputs("error: aes256pmacsiv AEAD: decryption failure\n", stderr);
+        abort();
+    }
+
+    assert(memcmp(buf, pt, sizeof(pt) - 1) == 0);
+}
+
+int main(int argc, char **argv) {
+    test_aead_aes128siv();
+    test_aead_aes256siv();
+    test_aead_aes128pmacsiv();
+    test_aead_aes256pmacsiv();
+
+    printf("%s: success\n", argv[0]);
+    return 0;
+}


### PR DESCRIPTION
Adds a C ABI which allows C/C++ or languages which support C ABI bindings to bind to the Rust implementation of Miscreant. See #107.

Also adds tests which ensure the C ABI is working as expected.