### PR TITLE
js/package.json: Upgrade all devDependencies

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -27,22 +27,22 @@
     "test": "mocha --require ts-node/register test/**/*.spec.ts"
   },
   "devDependencies": {
-    "@types/chai": "^4.0.10",
+    "@types/chai": "^4.1.2",
     "@types/chai-as-promised": "^7.1.0",
-    "@types/mocha": "^2.2.45",
-    "@types/node": "^8.5.2",
+    "@types/mocha": "^2.2.48",
+    "@types/node": "^8.9.4",
     "async-file": "^2.0.2",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "gulp": "^3.9.1",
-    "gulp-sourcemaps": "^2.6.3",
-    "gulp-typescript": "^3.1.6",
+    "gulp-sourcemaps": "^2.6.4",
+    "gulp-typescript": "^3.2.4",
     "mocha": "^4.1.0",
     "mocha-typescript": "^1.1.12",
-    "node-webcrypto-ossl": "1.0.26",
+    "node-webcrypto-ossl": "^1.0.35",
     "tjson-js": "^0.1.2",
     "ts-node": "^4.1.0",
-    "typescript": "^2.6.2",
+    "typescript": "^2.7.1",
     "webcrypto-core": "0.1.16"
   }
 }

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -29,27 +29,21 @@
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.5.1.tgz#9bd77fe12503ae00648b0945b38eab666adffe2e"
 
-"@types/chai@^4.0.10":
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.0.10.tgz#0eb222c7353adde8e0980bea04165d4d3b6afef3"
+"@types/chai@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.2.tgz#f1af664769cfb50af805431c407425ed619daa21"
 
-"@types/mkdirp@^0.3.29":
-  version "0.3.29"
-  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
+"@types/mocha@^2.2.48":
+  version "2.2.48"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"
 
-"@types/mocha@^2.2.45":
-  version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.45.tgz#816572b6e45164526a36d4faa123e8267d6d5d0a"
-  dependencies:
-    "@types/node" "*"
-
-"@types/node@*", "@types/node@^8.5.2":
-  version "8.5.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.2.tgz#83b8103fa9a2c2e83d78f701a9aa7c9539739aa5"
-
-"@types/node@^6", "@types/node@^6.0.45":
+"@types/node@^6":
   version "6.0.78"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.78.tgz#5d4a3f579c1524e01ee21bf474e6fba09198f470"
+
+"@types/node@^8.9.4":
+  version "8.9.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.9.4.tgz#dfd327582a06c114eb6e0441fa3d6fab35edad48"
 
 "@types/strip-bom@^3.0.0":
   version "3.0.0"
@@ -887,9 +881,9 @@ gulp-sourcemaps@1.6.0:
     through2 "^2.0.0"
     vinyl "^1.0.0"
 
-gulp-sourcemaps@^2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/gulp-sourcemaps/-/gulp-sourcemaps-2.6.3.tgz#11b033f759f909e0a5f15b7bdf47ac29cc54efa4"
+gulp-sourcemaps@^2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/gulp-sourcemaps/-/gulp-sourcemaps-2.6.4.tgz#cbb2008450b1bcce6cd23bf98337be751bf6e30a"
   dependencies:
     "@gulp-sourcemaps/identity-map" "1.X"
     "@gulp-sourcemaps/map-sources" "1.X"
@@ -899,13 +893,13 @@ gulp-sourcemaps@^2.6.3:
     debug-fabulous "1.X"
     detect-newline "2.X"
     graceful-fs "4.X"
-    source-map "0.X"
+    source-map "~0.6.0"
     strip-bom-string "1.X"
     through2 "2.X"
 
-gulp-typescript@^3.1.6:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/gulp-typescript/-/gulp-typescript-3.2.3.tgz#32d52ab97b97c4ce070c0419db08ea3af514d720"
+gulp-typescript@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/gulp-typescript/-/gulp-typescript-3.2.4.tgz#17c6b941078b02c0522974ed6c963ab190920a47"
   dependencies:
     gulp-util "~3.0.7"
     source-map "~0.5.3"
@@ -1569,9 +1563,9 @@ multipipe@^0.1.2:
   dependencies:
     duplexer2 "0.0.2"
 
-nan@^2.5.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+nan@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 nanomatch@^1.2.5:
   version "1.2.6"
@@ -1597,17 +1591,14 @@ next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
-node-webcrypto-ossl@1.0.26:
-  version "1.0.26"
-  resolved "https://registry.yarnpkg.com/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.26.tgz#c5e48d1dc25c87efd394f6edbe6fc33fe6fd5aed"
+node-webcrypto-ossl@^1.0.35:
+  version "1.0.35"
+  resolved "https://registry.yarnpkg.com/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.35.tgz#14225579bd09f5d63b0ad6cee0ba800f8c6a060d"
   dependencies:
-    "@types/mkdirp" "^0.3.29"
-    "@types/node" "^6.0.45"
     mkdirp "^0.5.1"
-    nan "^2.5.1"
-    tslib "^1.5.0"
-    typescript "^2"
-    webcrypto-core "^0.1.16"
+    nan "^2.8.0"
+    tslib "^1.8.1"
+    webcrypto-core "^0.1.19"
 
 normalize-package-data@^2.3.2:
   version "2.3.8"
@@ -2060,10 +2051,6 @@ source-map-url@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
 
-source-map@0.X, source-map@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
 source-map@^0.1.38:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
@@ -2073,6 +2060,10 @@ source-map@^0.1.38:
 source-map@^0.5.6, source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0, source-map@~0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 sparkles@^1.0.0:
   version "1.0.0"
@@ -2284,17 +2275,17 @@ tslib@^1.5.0:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
 
+tslib@^1.7.1, tslib@^1.8.1:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+
 type-detect@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.5.tgz#d70e5bc81db6de2a381bcaca0c6e0cbdc7635de2"
 
-typescript@^2:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.0.tgz#2e63e09284392bc8158a2444c33e2093795c0418"
-
-typescript@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 unc-path-regex@^0.1.2:
   version "0.1.2"
@@ -2432,12 +2423,18 @@ vinyl@^1.0.0:
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
 
-webcrypto-core@0.1.16, webcrypto-core@^0.1.16:
+webcrypto-core@0.1.16:
   version "0.1.16"
   resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-0.1.16.tgz#de4914b59148db73287bc4f8e61cf4fb2f56f020"
   dependencies:
     "@types/node" "^6"
     tslib "^1.5.0"
+
+webcrypto-core@^0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-0.1.19.tgz#f024e3a02bbca16ded46d26968c42535a39124dc"
+  dependencies:
+    tslib "^1.7.1"
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Updates all build dependencies to the latest version. Including
node-webcrypto-ossl after tracking down why versions between 1.0.31
and 1.0.35 triggered a regression.

Fixes #154