### PR TITLE
rust: Upgrade aesni crate to 0.3; use block-modes crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,15 @@ matrix:
   - language: rust
     rust: nightly
     before_script: cd rust
+    env:
+      - RUSTFLAGS=-Ctarget-feature=+aes
   - language: rust
     rust: nightly
     before_script: cd rust/tests/ffi
     env:
       - CC=clang
       - LDFLAGS=-rtlib=compiler-rt
+      - RUSTFLAGS=-Ctarget-feature=+aes
     script:
       - make
       - ./ffi_test

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "aesni"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-cipher-trait 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -19,6 +19,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "block-modes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-cipher-trait 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-padding 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
@@ -142,15 +156,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "miscreant"
 version = "0.3.0"
 dependencies = [
- "aesni 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "block-cipher-trait 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aesni 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-modes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pmac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -263,9 +276,11 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aesni 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7ba47de7c13f758a674d0685118346945e8bb0e2e906da6e36e403788a73662"
+"checksum aesni 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f167a87ec3aab2a7b5084689d2c6e7342dc0d865de8cd895cf95f820bf98164"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum block-cipher-trait 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6136d803280ae3532efa36114335255ea94f3d75d735ddedd66b0d7cd30bad3"
+"checksum block-modes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "862511b40f91a3305dc119fdfdc25b561779f78828495e41b71d360b8c9f56df"
+"checksum block-padding 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75bc2cfa52dc218b47ea000b15e6e5d00ca2f831db31e41592383c14d8802907"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,14 +14,13 @@ keywords    = ["cryptography", "encryption", "security", "streaming"]
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
-aesni = "0.2"
+aesni = "0.3"
 crypto-mac = "0.6"
-block-cipher-trait = "0.5"
+block-modes = "0.1"
 byteorder = { version = "1.2", default-features = false }
 clear_on_drop = { version = "0.2", features = ["nightly"] }
 cmac = "0.1"
 dbl = "0.1"
-generic-array = "0.9"
 pmac = "0.1"
 ring = { version = "0.11", optional = true }
 subtle = { version = "0.3", default-features = false }

--- a/rust/README.md
+++ b/rust/README.md
@@ -48,19 +48,28 @@ For more information, see the [toplevel README.md].
 
 ## Requirements
 
-This library presently requires the following:
+miscreant.rs presently requires the following:
 
 * **x86_64** CPU architecture
 * Rust **nightly** compiler
 
-This library implements the AES cipher using the [aesni] crate, which
-uses the [Intel AES-NI] CPU instructions to provide a fast, constant-time
-hardware-based implementation. No software-only implementation of AES is
-provided. Additionally it includes Intel assembly language implementations of
-certain secret-dependent functions which have verified constant-time operation.
+This is because it depends on the `aesni` crate which uses the `core::arch` API
+for (soon-to-be) stable access to CPU intrinsics, namely the [Intel AES-NI] CPU
+instructions which provide a hardware implementation of AES.
 
-Supporting stable Rust will require upstream changes in the [aesni] crate,
-which is nightly-only due to its use of inline assembly.
+To access these features, you will need both a relatively recent
+Rust nightly and to pass the following as RUSTFLAGS:
+
+```
+RUSTFLAGS=-C target-feature=+aes
+```
+
+You can configure your `~/.cargo/config` to always pass these flags:
+
+```toml
+[build]
+rustflags = ["-C", "target-feature=+aes"]
+```
 
 [aesni]: https://github.com/RustCrypto/block-ciphers
 [Intel AES-NI]: https://software.intel.com/en-us/blogs/2012/01/11/aes-ni-in-laymens-terms

--- a/rust/src/bench.rs
+++ b/rust/src/bench.rs
@@ -1,7 +1,7 @@
 extern crate ring;
 
 use self::ring::aead;
-use siv::{Aes128Siv, Aes128PmacSiv};
+use siv::{Aes128PmacSiv, Aes128Siv};
 use test::Bencher;
 
 // WARNING: Do not ever actually use a key of all zeroes
@@ -22,7 +22,9 @@ fn bench_aes_siv_128_encrypt_128_bytes(b: &mut Bencher) {
     let mut buffer = vec![0u8; 144];
     b.bytes = 128;
 
-    b.iter(|| { siv.seal_in_place(&[NONCE], &mut buffer); });
+    b.iter(|| {
+        siv.seal_in_place(&[NONCE], &mut buffer);
+    });
 }
 
 #[bench]
@@ -33,7 +35,9 @@ fn bench_aes_siv_128_encrypt_1024_bytes(b: &mut Bencher) {
     let mut buffer = vec![0u8; 1040];
     b.bytes = 1024;
 
-    b.iter(|| { siv.seal_in_place(&[NONCE], &mut buffer); });
+    b.iter(|| {
+        siv.seal_in_place(&[NONCE], &mut buffer);
+    });
 }
 
 #[bench]
@@ -44,7 +48,9 @@ fn bench_aes_siv_128_encrypt_16384_bytes(b: &mut Bencher) {
     let mut buffer = vec![0u8; 16400];
     b.bytes = 16384;
 
-    b.iter(|| { siv.seal_in_place(&[NONCE], &mut buffer); });
+    b.iter(|| {
+        siv.seal_in_place(&[NONCE], &mut buffer);
+    });
 }
 
 //
@@ -59,7 +65,9 @@ fn bench_aes_pmac_siv_128_encrypt_128_bytes(b: &mut Bencher) {
     let mut buffer = vec![0u8; 144];
     b.bytes = 128;
 
-    b.iter(|| { siv.seal_in_place(&[NONCE], &mut buffer); });
+    b.iter(|| {
+        siv.seal_in_place(&[NONCE], &mut buffer);
+    });
 }
 
 #[bench]
@@ -70,7 +78,9 @@ fn bench_aes_pmac_siv_128_encrypt_1024_bytes(b: &mut Bencher) {
     let mut buffer = vec![0u8; 1040];
     b.bytes = 1024;
 
-    b.iter(|| { siv.seal_in_place(&[NONCE], &mut buffer); });
+    b.iter(|| {
+        siv.seal_in_place(&[NONCE], &mut buffer);
+    });
 }
 
 #[bench]
@@ -81,7 +91,9 @@ fn bench_aes_pmac_siv_128_encrypt_16384_bytes(b: &mut Bencher) {
     let mut buffer = vec![0u8; 16400];
     b.bytes = 16384;
 
-    b.iter(|| { siv.seal_in_place(&[NONCE], &mut buffer); });
+    b.iter(|| {
+        siv.seal_in_place(&[NONCE], &mut buffer);
+    });
 }
 
 //
@@ -90,8 +102,8 @@ fn bench_aes_pmac_siv_128_encrypt_16384_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_aes_gcm_128_encrypt_128_bytes(b: &mut Bencher) {
-    let sealing_key = aead::SealingKey::new(&aead::AES_128_GCM, &KEY_128_BIT[..])
-        .expect("valid key");
+    let sealing_key =
+        aead::SealingKey::new(&aead::AES_128_GCM, &KEY_128_BIT[..]).expect("valid key");
 
     // 128 bytes input + 16 bytes tag
     let mut buffer = [0u8; 144];
@@ -110,8 +122,8 @@ fn bench_aes_gcm_128_encrypt_128_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_aes_gcm_128_encrypt_1024_bytes(b: &mut Bencher) {
-    let sealing_key = aead::SealingKey::new(&aead::AES_128_GCM, &KEY_128_BIT[..])
-        .expect("valid key");
+    let sealing_key =
+        aead::SealingKey::new(&aead::AES_128_GCM, &KEY_128_BIT[..]).expect("valid key");
 
     // 1024 bytes input + 16 bytes tag
     let mut buffer = [0u8; 1040];
@@ -130,8 +142,8 @@ fn bench_aes_gcm_128_encrypt_1024_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_aes_gcm_128_encrypt_16384_bytes(b: &mut Bencher) {
-    let sealing_key = aead::SealingKey::new(&aead::AES_128_GCM, &KEY_128_BIT[..])
-        .expect("valid key");
+    let sealing_key =
+        aead::SealingKey::new(&aead::AES_128_GCM, &KEY_128_BIT[..]).expect("valid key");
 
     // 16384 bytes input + 16 bytes tag
     let mut buffer = [0u8; 16400];

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1,12 +1,11 @@
 //! `ffi.rs`: Foreign Function Interface providing C ABI
 
 // This is the only code in Miscreant allowed to be unsafe
-#![allow(unsafe_code)]
-#![allow(non_upper_case_globals)]
+#![allow(unsafe_code, non_upper_case_globals, unknown_lints, too_many_arguments)]
 
 use aead;
+use aesni::block_cipher_trait::generic_array::typenum::Unsigned;
 use core::{ptr, slice};
-use generic_array::typenum::Unsigned;
 
 //
 // AES-128-SIV AEAD
@@ -25,17 +24,7 @@ pub unsafe extern "C" fn crypto_aead_aes128siv_encrypt(
     adlen: u64,
     key: *const u8,
 ) -> i32 {
-    aead_encrypt::<aead::Aes128Siv>(
-        ct,
-        ctlen_p,
-        msg,
-        msglen,
-        nonce,
-        noncelen,
-        ad,
-        adlen,
-        key,
-    )
+    aead_encrypt::<aead::Aes128Siv>(ct, ctlen_p, msg, msglen, nonce, noncelen, ad, adlen, key)
 }
 
 /// AES-128-SIV AEAD: authenticated decryption
@@ -51,17 +40,7 @@ pub unsafe extern "C" fn crypto_aead_aes128siv_decrypt(
     adlen: u64,
     key: *const u8,
 ) -> i32 {
-    aead_decrypt::<aead::Aes128Siv>(
-        msg,
-        msglen_p,
-        ct,
-        ctlen,
-        nonce,
-        noncelen,
-        ad,
-        adlen,
-        key,
-    )
+    aead_decrypt::<aead::Aes128Siv>(msg, msglen_p, ct, ctlen, nonce, noncelen, ad, adlen, key)
 }
 
 /// AES-128-SIV key size
@@ -89,17 +68,7 @@ pub unsafe extern "C" fn crypto_aead_aes256siv_encrypt(
     adlen: u64,
     key: *const u8,
 ) -> i32 {
-    aead_encrypt::<aead::Aes256Siv>(
-        ct,
-        ctlen_p,
-        msg,
-        msglen,
-        nonce,
-        noncelen,
-        ad,
-        adlen,
-        key,
-    )
+    aead_encrypt::<aead::Aes256Siv>(ct, ctlen_p, msg, msglen, nonce, noncelen, ad, adlen, key)
 }
 
 /// AES-256-SIV AEAD: authenticated decryption
@@ -115,17 +84,7 @@ pub unsafe extern "C" fn crypto_aead_aes256siv_decrypt(
     adlen: u64,
     key: *const u8,
 ) -> i32 {
-    aead_decrypt::<aead::Aes256Siv>(
-        msg,
-        msglen_p,
-        ct,
-        ctlen,
-        nonce,
-        noncelen,
-        ad,
-        adlen,
-        key,
-    )
+    aead_decrypt::<aead::Aes256Siv>(msg, msglen_p, ct, ctlen, nonce, noncelen, ad, adlen, key)
 }
 
 /// AES-128-SIV key size
@@ -153,17 +112,7 @@ pub unsafe extern "C" fn crypto_aead_aes128pmacsiv_encrypt(
     adlen: u64,
     key: *const u8,
 ) -> i32 {
-    aead_encrypt::<aead::Aes128PmacSiv>(
-        ct,
-        ctlen_p,
-        msg,
-        msglen,
-        nonce,
-        noncelen,
-        ad,
-        adlen,
-        key,
-    )
+    aead_encrypt::<aead::Aes128PmacSiv>(ct, ctlen_p, msg, msglen, nonce, noncelen, ad, adlen, key)
 }
 
 /// AES-128-PMAC-SIV AEAD: authenticated decryption
@@ -179,17 +128,7 @@ pub unsafe extern "C" fn crypto_aead_aes128pmacsiv_decrypt(
     adlen: u64,
     key: *const u8,
 ) -> i32 {
-    aead_decrypt::<aead::Aes128PmacSiv>(
-        msg,
-        msglen_p,
-        ct,
-        ctlen,
-        nonce,
-        noncelen,
-        ad,
-        adlen,
-        key,
-    )
+    aead_decrypt::<aead::Aes128PmacSiv>(msg, msglen_p, ct, ctlen, nonce, noncelen, ad, adlen, key)
 }
 
 /// AES-128-PMAC-SIV key size
@@ -217,17 +156,7 @@ pub unsafe extern "C" fn crypto_aead_aes256pmacsiv_encrypt(
     adlen: u64,
     key: *const u8,
 ) -> i32 {
-    aead_encrypt::<aead::Aes256PmacSiv>(
-        ct,
-        ctlen_p,
-        msg,
-        msglen,
-        nonce,
-        noncelen,
-        ad,
-        adlen,
-        key,
-    )
+    aead_encrypt::<aead::Aes256PmacSiv>(ct, ctlen_p, msg, msglen, nonce, noncelen, ad, adlen, key)
 }
 
 /// AES-256-PMAC-SIV AEAD: authenticated decryption
@@ -243,17 +172,7 @@ pub unsafe extern "C" fn crypto_aead_aes256pmacsiv_decrypt(
     adlen: u64,
     key: *const u8,
 ) -> i32 {
-    aead_decrypt::<aead::Aes256PmacSiv>(
-        msg,
-        msglen_p,
-        ct,
-        ctlen,
-        nonce,
-        noncelen,
-        ad,
-        adlen,
-        key,
-    )
+    aead_decrypt::<aead::Aes256PmacSiv>(msg, msglen_p, ct, ctlen, nonce, noncelen, ad, adlen, key)
 }
 
 /// AES-128-SIV key size
@@ -296,7 +215,7 @@ unsafe fn aead_encrypt<A: aead::Algorithm>(
 
     A::new(key_slice).seal_in_place(nonce_slice, ad_slice, ct_slice);
 
-    return 0;
+    0
 }
 
 /// Generic C-like interface to AEAD decryption
@@ -345,5 +264,5 @@ unsafe fn aead_decrypt<A: aead::Algorithm>(
         *c = 0;
     }
 
-    return 0;
+    0
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,24 +1,38 @@
 //! `Miscreant`: Misuse resistant symmetric encryption library providing the
 //! AES-SIV (RFC 5297), AES-PMAC-SIV, and STREAM constructions
-
+//!
+//! # Build Notes
+//!
+//! This crate depends on the `aesni` crate, which uses the new `core::arch`
+//! API to invoke CPU instructions for performing AES in hardware.
+//!
+//! To access these features, you will need both a relatively recent
+//! Rust nightly and to pass the following as RUSTFLAGS:
+//!
+//! `RUSTFLAGS=-C target-feature=+aes`
+//!
+//! You can configure your `~/.cargo/config` to always pass these flags:
+//!
+//! ```toml
+//! [build]
+//! rustflags = ["-C", "target-feature=+aes"]
+//! ```
+//!
 #![crate_name = "miscreant"]
 #![crate_type = "lib"]
-
 #![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "bench", feature(test))]
 #![cfg_attr(feature = "staticlib", feature(lang_items))]
 
 extern crate aesni;
+extern crate block_modes;
 extern crate byteorder;
-extern crate block_cipher_trait;
 extern crate clear_on_drop;
 extern crate cmac;
 extern crate crypto_mac;
 extern crate dbl;
-extern crate generic_array;
 extern crate pmac;
 extern crate subtle;
 

--- a/rust/src/s2v.rs
+++ b/rust/src/s2v.rs
@@ -1,7 +1,7 @@
+use aesni::block_cipher_trait::generic_array::GenericArray;
+use aesni::block_cipher_trait::generic_array::typenum::{U16, Unsigned};
 use crypto_mac::Mac;
 use dbl::Dbl;
-use generic_array::GenericArray;
-use generic_array::typenum::{U16, Unsigned};
 
 /// Maximum number of associated data items
 pub const MAX_ASSOCIATED_DATA: usize = 126;

--- a/rust/src/stream.rs
+++ b/rust/src/stream.rs
@@ -1,7 +1,7 @@
 //! `stream.rs`: The STREAM online authenticated encryption construction.
 //! See <https://eprint.iacr.org/2015/189.pdf> for definition.
 
-use aead::{self, Aes128Siv, Aes128PmacSiv, Aes256Siv, Aes256PmacSiv};
+use aead::{self, Aes128PmacSiv, Aes128Siv, Aes256PmacSiv, Aes256Siv};
 use byteorder::{BigEndian, ByteOrder};
 use error::Error;
 
@@ -183,9 +183,9 @@ impl NonceEncoder32 {
 
     /// Increment the nonce value in-place
     pub fn increment(&mut self) {
-        self.counter = self.counter.checked_add(1).expect(
-            "STREAM nonce counter overflowed",
-        );
+        self.counter = self.counter
+            .checked_add(1)
+            .expect("STREAM nonce counter overflowed");
 
         BigEndian::write_u32(&mut self.value[NONCE_SIZE..(NONCE_SIZE + 4)], self.counter);
     }

--- a/rust/tests/aead_test.rs
+++ b/rust/tests/aead_test.rs
@@ -3,7 +3,7 @@ extern crate miscreant;
 mod aead_vectors;
 
 use aead_vectors::AesSivAeadExample;
-use miscreant::aead::{Aes128Siv, Aes256Siv, Aes128PmacSiv, Aes256PmacSiv, Algorithm};
+use miscreant::aead::{Aes128PmacSiv, Aes128Siv, Aes256PmacSiv, Aes256Siv, Algorithm};
 
 #[test]
 fn aes_siv_aead_examples_seal() {
@@ -11,44 +11,32 @@ fn aes_siv_aead_examples_seal() {
 
     for example in examples {
         let ciphertext = match example.alg.as_ref() {
-            "AES-SIV" => {
-                match example.key.len() {
-                    32 => {
-                        Aes128Siv::new(&example.key).seal(
-                            &example.nonce,
-                            &example.ad,
-                            &example.plaintext,
-                        )
-                    }
-                    64 => {
-                        Aes256Siv::new(&example.key).seal(
-                            &example.nonce,
-                            &example.ad,
-                            &example.plaintext,
-                        )
-                    }
-                    _ => panic!("unexpected key size: {}", example.key.len()),
-                }
-            }
-            "AES-PMAC-SIV" => {
-                match example.key.len() {
-                    32 => {
-                        Aes128PmacSiv::new(&example.key).seal(
-                            &example.nonce,
-                            &example.ad,
-                            &example.plaintext,
-                        )
-                    }
-                    64 => {
-                        Aes256PmacSiv::new(&example.key).seal(
-                            &example.nonce,
-                            &example.ad,
-                            &example.plaintext,
-                        )
-                    }
-                    _ => panic!("unexpected key size: {}", example.key.len()),
-                }
-            }
+            "AES-SIV" => match example.key.len() {
+                32 => Aes128Siv::new(&example.key).seal(
+                    &example.nonce,
+                    &example.ad,
+                    &example.plaintext,
+                ),
+                64 => Aes256Siv::new(&example.key).seal(
+                    &example.nonce,
+                    &example.ad,
+                    &example.plaintext,
+                ),
+                _ => panic!("unexpected key size: {}", example.key.len()),
+            },
+            "AES-PMAC-SIV" => match example.key.len() {
+                32 => Aes128PmacSiv::new(&example.key).seal(
+                    &example.nonce,
+                    &example.ad,
+                    &example.plaintext,
+                ),
+                64 => Aes256PmacSiv::new(&example.key).seal(
+                    &example.nonce,
+                    &example.ad,
+                    &example.plaintext,
+                ),
+                _ => panic!("unexpected key size: {}", example.key.len()),
+            },
             _ => panic!("unexpected algorithm: {}", example.alg),
         };
 
@@ -62,44 +50,32 @@ fn aes_siv_aead_examples_open() {
 
     for example in examples {
         let plaintext = match example.alg.as_ref() {
-            "AES-SIV" => {
-                match example.key.len() {
-                    32 => {
-                        Aes128Siv::new(&example.key).open(
-                            &example.nonce,
-                            &example.ad,
-                            &example.ciphertext,
-                        )
-                    }
-                    64 => {
-                        Aes256Siv::new(&example.key).open(
-                            &example.nonce,
-                            &example.ad,
-                            &example.ciphertext,
-                        )
-                    }
-                    _ => panic!("unexpected key size: {}", example.key.len()),
-                }
-            }
-            "AES-PMAC-SIV" => {
-                match example.key.len() {
-                    32 => {
-                        Aes128PmacSiv::new(&example.key).open(
-                            &example.nonce,
-                            &example.ad,
-                            &example.ciphertext,
-                        )
-                    }
-                    64 => {
-                        Aes256PmacSiv::new(&example.key).open(
-                            &example.nonce,
-                            &example.ad,
-                            &example.ciphertext,
-                        )
-                    }
-                    _ => panic!("unexpected key size: {}", example.key.len()),
-                }
-            }
+            "AES-SIV" => match example.key.len() {
+                32 => Aes128Siv::new(&example.key).open(
+                    &example.nonce,
+                    &example.ad,
+                    &example.ciphertext,
+                ),
+                64 => Aes256Siv::new(&example.key).open(
+                    &example.nonce,
+                    &example.ad,
+                    &example.ciphertext,
+                ),
+                _ => panic!("unexpected key size: {}", example.key.len()),
+            },
+            "AES-PMAC-SIV" => match example.key.len() {
+                32 => Aes128PmacSiv::new(&example.key).open(
+                    &example.nonce,
+                    &example.ad,
+                    &example.ciphertext,
+                ),
+                64 => Aes256PmacSiv::new(&example.key).open(
+                    &example.nonce,
+                    &example.ad,
+                    &example.ciphertext,
+                ),
+                _ => panic!("unexpected key size: {}", example.key.len()),
+            },
             _ => panic!("unexpected algorithm: {}", example.alg),
         }.expect("decrypt failure");
 

--- a/rust/tests/aead_vectors/mod.rs
+++ b/rust/tests/aead_vectors/mod.rs
@@ -30,53 +30,50 @@ impl AesSivAeadExample {
         let mut file = File::open(&path).expect("valid aes_siv_aead.tjson");
         let mut tjson_string = String::new();
 
-        file.read_to_string(&mut tjson_string).expect(
-            "aes_siv_aead.tjson read successfully",
-        );
+        file.read_to_string(&mut tjson_string)
+            .expect("aes_siv_aead.tjson read successfully");
 
         let tjson: serde_json::Value =
             serde_json::from_str(&tjson_string).expect("aes_siv.tjson parses successfully");
 
-        let examples = &tjson["examples:A<O>"].as_array().expect(
-            "aes_siv_aead.tjson examples array",
-        );
+        let examples = &tjson["examples:A<O>"]
+            .as_array()
+            .expect("aes_siv_aead.tjson examples array");
 
         examples
             .into_iter()
-            .map(|ex| {
-                Self {
-                    alg: ex["alg:s"].as_str().expect("algorithm name").to_owned(),
-                    key: HEXLOWER
-                        .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
-                        .expect("hex encoded"),
-                    ad: HEXLOWER
-                        .decode(ex["ad:d16"].as_str().expect("encoded example").as_bytes())
-                        .expect("hex encoded"),
-                    nonce: HEXLOWER
-                        .decode(
-                            ex["nonce:d16"]
-                                .as_str()
-                                .expect("encoded example")
-                                .as_bytes(),
-                        )
-                        .expect("hex encoded"),
-                    plaintext: HEXLOWER
-                        .decode(
-                            ex["plaintext:d16"]
-                                .as_str()
-                                .expect("encoded example")
-                                .as_bytes(),
-                        )
-                        .expect("hex encoded"),
-                    ciphertext: HEXLOWER
-                        .decode(
-                            ex["ciphertext:d16"]
-                                .as_str()
-                                .expect("encoded example")
-                                .as_bytes(),
-                        )
-                        .expect("hex encoded"),
-                }
+            .map(|ex| Self {
+                alg: ex["alg:s"].as_str().expect("algorithm name").to_owned(),
+                key: HEXLOWER
+                    .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                    .expect("hex encoded"),
+                ad: HEXLOWER
+                    .decode(ex["ad:d16"].as_str().expect("encoded example").as_bytes())
+                    .expect("hex encoded"),
+                nonce: HEXLOWER
+                    .decode(
+                        ex["nonce:d16"]
+                            .as_str()
+                            .expect("encoded example")
+                            .as_bytes(),
+                    )
+                    .expect("hex encoded"),
+                plaintext: HEXLOWER
+                    .decode(
+                        ex["plaintext:d16"]
+                            .as_str()
+                            .expect("encoded example")
+                            .as_bytes(),
+                    )
+                    .expect("hex encoded"),
+                ciphertext: HEXLOWER
+                    .decode(
+                        ex["ciphertext:d16"]
+                            .as_str()
+                            .expect("encoded example")
+                            .as_bytes(),
+                    )
+                    .expect("hex encoded"),
             })
             .collect()
     }

--- a/rust/tests/siv_test.rs
+++ b/rust/tests/siv_test.rs
@@ -2,8 +2,8 @@ extern crate miscreant;
 
 mod siv_vectors;
 
-use miscreant::siv::{Aes128Siv, Aes256Siv, Aes128PmacSiv, Aes256PmacSiv};
-use siv_vectors::{AesSivExample, AesPmacSivExample};
+use miscreant::siv::{Aes128PmacSiv, Aes128Siv, Aes256PmacSiv, Aes256Siv};
+use siv_vectors::{AesPmacSivExample, AesSivExample};
 
 #[test]
 fn aes_siv_examples_seal() {

--- a/rust/tests/siv_vectors/mod.rs
+++ b/rust/tests/siv_vectors/mod.rs
@@ -27,50 +27,47 @@ impl AesSivExample {
     pub fn load_from_file(path: &Path) -> Vec<Self> {
         let mut file = File::open(&path).expect("valid aes_siv.tjson");
         let mut tjson_string = String::new();
-        file.read_to_string(&mut tjson_string).expect(
-            "aes_siv.tjson read successfully",
-        );
+        file.read_to_string(&mut tjson_string)
+            .expect("aes_siv.tjson read successfully");
 
         let tjson: serde_json::Value =
             serde_json::from_str(&tjson_string).expect("aes_siv.tjson parses successfully");
-        let examples = &tjson["examples:A<O>"].as_array().expect(
-            "aes_siv.tjson examples array",
-        );
+        let examples = &tjson["examples:A<O>"]
+            .as_array()
+            .expect("aes_siv.tjson examples array");
 
         examples
             .into_iter()
-            .map(|ex| {
-                Self {
-                    key: HEXLOWER
-                        .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
-                        .expect("hex encoded"),
-                    ad: ex["ad:A<d16>"]
-                        .as_array()
-                        .expect("encoded example")
-                        .iter()
-                        .map(|ex| {
-                            HEXLOWER
-                                .decode(ex.as_str().expect("encoded example").as_bytes())
-                                .expect("hex encoded")
-                        })
-                        .collect(),
-                    plaintext: HEXLOWER
-                        .decode(
-                            ex["plaintext:d16"]
-                                .as_str()
-                                .expect("encoded example")
-                                .as_bytes(),
-                        )
-                        .expect("hex encoded"),
-                    ciphertext: HEXLOWER
-                        .decode(
-                            ex["ciphertext:d16"]
-                                .as_str()
-                                .expect("encoded example")
-                                .as_bytes(),
-                        )
-                        .expect("hex encoded"),
-                }
+            .map(|ex| Self {
+                key: HEXLOWER
+                    .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                    .expect("hex encoded"),
+                ad: ex["ad:A<d16>"]
+                    .as_array()
+                    .expect("encoded example")
+                    .iter()
+                    .map(|ex| {
+                        HEXLOWER
+                            .decode(ex.as_str().expect("encoded example").as_bytes())
+                            .expect("hex encoded")
+                    })
+                    .collect(),
+                plaintext: HEXLOWER
+                    .decode(
+                        ex["plaintext:d16"]
+                            .as_str()
+                            .expect("encoded example")
+                            .as_bytes(),
+                    )
+                    .expect("hex encoded"),
+                ciphertext: HEXLOWER
+                    .decode(
+                        ex["ciphertext:d16"]
+                            .as_str()
+                            .expect("encoded example")
+                            .as_bytes(),
+                    )
+                    .expect("hex encoded"),
             })
             .collect()
     }
@@ -96,50 +93,47 @@ impl AesPmacSivExample {
     pub fn load_from_file(path: &Path) -> Vec<Self> {
         let mut file = File::open(&path).expect("valid aes_pmac_siv.tjson");
         let mut tjson_string = String::new();
-        file.read_to_string(&mut tjson_string).expect(
-            "aes_pmac_siv.tjson read successfully",
-        );
+        file.read_to_string(&mut tjson_string)
+            .expect("aes_pmac_siv.tjson read successfully");
 
         let tjson: serde_json::Value =
             serde_json::from_str(&tjson_string).expect("aes_pmac_siv.tjson parses successfully");
-        let examples = &tjson["examples:A<O>"].as_array().expect(
-            "aes_pmac_siv.tjson examples array",
-        );
+        let examples = &tjson["examples:A<O>"]
+            .as_array()
+            .expect("aes_pmac_siv.tjson examples array");
 
         examples
             .into_iter()
-            .map(|ex| {
-                Self {
-                    key: HEXLOWER
-                        .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
-                        .expect("hex encoded"),
-                    ad: ex["ad:A<d16>"]
-                        .as_array()
-                        .expect("encoded example")
-                        .iter()
-                        .map(|ex| {
-                            HEXLOWER
-                                .decode(ex.as_str().expect("encoded example").as_bytes())
-                                .expect("hex encoded")
-                        })
-                        .collect(),
-                    plaintext: HEXLOWER
-                        .decode(
-                            ex["plaintext:d16"]
-                                .as_str()
-                                .expect("encoded example")
-                                .as_bytes(),
-                        )
-                        .expect("hex encoded"),
-                    ciphertext: HEXLOWER
-                        .decode(
-                            ex["ciphertext:d16"]
-                                .as_str()
-                                .expect("encoded example")
-                                .as_bytes(),
-                        )
-                        .expect("hex encoded"),
-                }
+            .map(|ex| Self {
+                key: HEXLOWER
+                    .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                    .expect("hex encoded"),
+                ad: ex["ad:A<d16>"]
+                    .as_array()
+                    .expect("encoded example")
+                    .iter()
+                    .map(|ex| {
+                        HEXLOWER
+                            .decode(ex.as_str().expect("encoded example").as_bytes())
+                            .expect("hex encoded")
+                    })
+                    .collect(),
+                plaintext: HEXLOWER
+                    .decode(
+                        ex["plaintext:d16"]
+                            .as_str()
+                            .expect("encoded example")
+                            .as_bytes(),
+                    )
+                    .expect("hex encoded"),
+                ciphertext: HEXLOWER
+                    .decode(
+                        ex["ciphertext:d16"]
+                            .as_str()
+                            .expect("encoded example")
+                            .as_bytes(),
+                    )
+                    .expect("hex encoded"),
             })
             .collect()
     }

--- a/rust/tests/stream_test.rs
+++ b/rust/tests/stream_test.rs
@@ -1,38 +1,29 @@
 extern crate miscreant;
-extern crate generic_array;
 
 mod stream_vectors;
 
 use miscreant::aead;
-use miscreant::stream::{Aes128PmacSivEncryptor, Aes128PmacSivDecryptor};
-use miscreant::stream::{Aes128SivEncryptor, Aes128SivDecryptor};
-use miscreant::stream::{Aes256PmacSivEncryptor, Aes256PmacSivDecryptor};
-use miscreant::stream::{Aes256SivEncryptor, Aes256SivDecryptor};
-use miscreant::stream::{Encryptor, Decryptor};
+use miscreant::stream::{Aes128PmacSivDecryptor, Aes128PmacSivEncryptor};
+use miscreant::stream::{Aes128SivDecryptor, Aes128SivEncryptor};
+use miscreant::stream::{Aes256PmacSivDecryptor, Aes256PmacSivEncryptor};
+use miscreant::stream::{Aes256SivDecryptor, Aes256SivEncryptor};
+use miscreant::stream::{Decryptor, Encryptor};
 use stream_vectors::{AesSivStreamExample, Block};
 
 #[test]
 fn aes_siv_stream_examples_seal() {
     for ex in AesSivStreamExample::load_all() {
         match ex.alg.as_ref() {
-            "AES-SIV" => {
-                match ex.key.len() {
-                    32 => test_encryptor(Aes128SivEncryptor::new(&ex.key, &ex.nonce), &ex.blocks),
-                    64 => test_encryptor(Aes256SivEncryptor::new(&ex.key, &ex.nonce), &ex.blocks),
-                    _ => panic!("unexpected key size: {}", ex.key.len()),
-                }
-            }
-            "AES-PMAC-SIV" => {
-                match ex.key.len() {
-                    32 => {
-                        test_encryptor(Aes128PmacSivEncryptor::new(&ex.key, &ex.nonce), &ex.blocks)
-                    }
-                    64 => {
-                        test_encryptor(Aes256PmacSivEncryptor::new(&ex.key, &ex.nonce), &ex.blocks)
-                    }
-                    _ => panic!("unexpected key size: {}", ex.key.len()),
-                }
-            }
+            "AES-SIV" => match ex.key.len() {
+                32 => test_encryptor(Aes128SivEncryptor::new(&ex.key, &ex.nonce), &ex.blocks),
+                64 => test_encryptor(Aes256SivEncryptor::new(&ex.key, &ex.nonce), &ex.blocks),
+                _ => panic!("unexpected key size: {}", ex.key.len()),
+            },
+            "AES-PMAC-SIV" => match ex.key.len() {
+                32 => test_encryptor(Aes128PmacSivEncryptor::new(&ex.key, &ex.nonce), &ex.blocks),
+                64 => test_encryptor(Aes256PmacSivEncryptor::new(&ex.key, &ex.nonce), &ex.blocks),
+                _ => panic!("unexpected key size: {}", ex.key.len()),
+            },
             _ => panic!("unexpected algorithm: {}", ex.alg),
         }
     }
@@ -55,24 +46,16 @@ fn test_encryptor<A: aead::Algorithm>(mut encryptor: Encryptor<A>, blocks: &[Blo
 fn aes_siv_stream_examples_open() {
     for ex in AesSivStreamExample::load_all() {
         match ex.alg.as_ref() {
-            "AES-SIV" => {
-                match ex.key.len() {
-                    32 => test_decryptor(Aes128SivDecryptor::new(&ex.key, &ex.nonce), &ex.blocks),
-                    64 => test_decryptor(Aes256SivDecryptor::new(&ex.key, &ex.nonce), &ex.blocks),
-                    _ => panic!("unexpected key size: {}", ex.key.len()),
-                }
-            }
-            "AES-PMAC-SIV" => {
-                match ex.key.len() {
-                    32 => {
-                        test_decryptor(Aes128PmacSivDecryptor::new(&ex.key, &ex.nonce), &ex.blocks)
-                    }
-                    64 => {
-                        test_decryptor(Aes256PmacSivDecryptor::new(&ex.key, &ex.nonce), &ex.blocks)
-                    }
-                    _ => panic!("unexpected key size: {}", ex.key.len()),
-                }
-            }
+            "AES-SIV" => match ex.key.len() {
+                32 => test_decryptor(Aes128SivDecryptor::new(&ex.key, &ex.nonce), &ex.blocks),
+                64 => test_decryptor(Aes256SivDecryptor::new(&ex.key, &ex.nonce), &ex.blocks),
+                _ => panic!("unexpected key size: {}", ex.key.len()),
+            },
+            "AES-PMAC-SIV" => match ex.key.len() {
+                32 => test_decryptor(Aes128PmacSivDecryptor::new(&ex.key, &ex.nonce), &ex.blocks),
+                64 => test_decryptor(Aes256PmacSivDecryptor::new(&ex.key, &ex.nonce), &ex.blocks),
+                _ => panic!("unexpected key size: {}", ex.key.len()),
+            },
             _ => panic!("unexpected algorithm: {}", ex.alg),
         }
     }
@@ -81,15 +64,15 @@ fn aes_siv_stream_examples_open() {
 fn test_decryptor<A: aead::Algorithm>(mut decryptor: Decryptor<A>, blocks: &[Block]) {
     for (i, block) in blocks.iter().enumerate() {
         if i < blocks.len() - 1 {
-            let plaintext = decryptor.open_next(&block.ad, &block.ciphertext).expect(
-                "decrypt failure",
-            );
+            let plaintext = decryptor
+                .open_next(&block.ad, &block.ciphertext)
+                .expect("decrypt failure");
 
             assert_eq!(plaintext, block.plaintext);
         } else {
-            let plaintext = decryptor.open_last(&block.ad, &block.ciphertext).expect(
-                "decrypt failure",
-            );
+            let plaintext = decryptor
+                .open_last(&block.ad, &block.ciphertext)
+                .expect("decrypt failure");
 
             assert_eq!(plaintext, block.plaintext);
             return;

--- a/rust/tests/stream_vectors/mod.rs
+++ b/rust/tests/stream_vectors/mod.rs
@@ -35,64 +35,57 @@ impl AesSivStreamExample {
         let mut file = File::open(&path).expect("valid aes_siv_stream.tjson");
         let mut tjson_string = String::new();
 
-        file.read_to_string(&mut tjson_string).expect(
-            "aes_siv_stream.tjson read successfully",
-        );
+        file.read_to_string(&mut tjson_string)
+            .expect("aes_siv_stream.tjson read successfully");
 
         let tjson: serde_json::Value =
             serde_json::from_str(&tjson_string).expect("aes_siv_stream.tjson parses successfully");
 
-        let examples = &tjson["examples:A<O>"].as_array().expect(
-            "aes_siv_stream.tjson examples array",
-        );
+        let examples = &tjson["examples:A<O>"]
+            .as_array()
+            .expect("aes_siv_stream.tjson examples array");
 
         examples
             .into_iter()
-            .map(|ex| {
-                Self {
-                    alg: ex["alg:s"].as_str().expect("algorithm name").to_owned(),
-                    key: HEXLOWER
-                        .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
-                        .expect("hex encoded"),
-                    nonce: HEXLOWER
-                        .decode(
-                            ex["nonce:d16"]
-                                .as_str()
-                                .expect("encoded example")
-                                .as_bytes(),
-                        )
-                        .expect("hex encoded"),
-                    blocks: ex["blocks:A<O>"]
-                        .as_array()
-                        .expect("encoded example")
-                        .iter()
-                        .map(|ex| {
-                            Block {
-                                ad: HEXLOWER
-                                    .decode(
-                                        ex["ad:d16"].as_str().expect("encoded example").as_bytes(),
-                                    )
-                                    .expect("hex encoded"),
-                                plaintext: HEXLOWER
-                                    .decode(
-                                        ex["plaintext:d16"]
-                                            .as_str()
-                                            .expect("encoded example")
-                                            .as_bytes(),
-                                    )
-                                    .expect("hex encoded"),
-                                ciphertext: HEXLOWER
-                                    .decode(
-                                        ex["ciphertext:d16"]
-                                            .as_str()
-                                            .expect("encoded example")
-                                            .as_bytes(),
-                                    )
-                                    .expect("hex encoded"),
-                            }
-                        })
-                        .collect(),
-                }
+            .map(|ex| Self {
+                alg: ex["alg:s"].as_str().expect("algorithm name").to_owned(),
+                key: HEXLOWER
+                    .decode(ex["key:d16"].as_str().expect("encoded example").as_bytes())
+                    .expect("hex encoded"),
+                nonce: HEXLOWER
+                    .decode(
+                        ex["nonce:d16"]
+                            .as_str()
+                            .expect("encoded example")
+                            .as_bytes(),
+                    )
+                    .expect("hex encoded"),
+                blocks: ex["blocks:A<O>"]
+                    .as_array()
+                    .expect("encoded example")
+                    .iter()
+                    .map(|ex| Block {
+                        ad: HEXLOWER
+                            .decode(ex["ad:d16"].as_str().expect("encoded example").as_bytes())
+                            .expect("hex encoded"),
+                        plaintext: HEXLOWER
+                            .decode(
+                                ex["plaintext:d16"]
+                                    .as_str()
+                                    .expect("encoded example")
+                                    .as_bytes(),
+                            )
+                            .expect("hex encoded"),
+                        ciphertext: HEXLOWER
+                            .decode(
+                                ex["ciphertext:d16"]
+                                    .as_str()
+                                    .expect("encoded example")
+                                    .as_bytes(),
+                            )
+                            .expect("hex encoded"),
+                    })
+                    .collect(),
             })
             .collect()
     }


### PR DESCRIPTION
This upgrades to the new `core::arch`-based aesni 0.3 crate, which drops its previous AES-CTR API, and so we use the one from the new block-modes crate.

The particular implementation in this change breaks the current API a bit in regard to the type signatures of heavily generic bits like `Siv` and `SivAlgorithm`. It'd be nice to refactor so as to introduce fewer type parameters, but this at least gets the crate(s) upgraded.