### PR TITLE
rust: Allow failures on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ branches:
 
 matrix:
   fast_finish: true
+  allow_failures:
+  - rust: nightly
   include:
   - language: go
     go: 1.9


### PR DESCRIPTION
The build is presently broken because bits of the `no_std` API changed:

https://travis-ci.org/miscreant/miscreant/jobs/394811801

Miscreant will build on stable Rust as of tomorrow, and `nightly` is a moving target, so allow failures on `nightly` in the hope that we will be able to guarantee consistent, reproducible builds on stable.