### PR TITLE
Adding a flag that makes docs.rs build all documentation

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,3 +52,6 @@ rpath = false
 lto = false
 debug-assertions = false
 codegen-units = 1
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
This is a common issue with optional features, where `docs.rs` doesn't build all documentation. This flag in the `Cargo.toml` fixes that and makes sure people can read all the docs! :grin: