### PR TITLE
rust: Only build the `std` feature on docs.rs

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,5 +55,5 @@ debug-assertions = false
 codegen-units = 1
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["std"]
 rustc-args = ["-Ctarget-feature=+aes"]


### PR DESCRIPTION
Otherwise the test fails due to the "bench" feature

Separately, we should really switch to criterion.rs